### PR TITLE
ci: attach only plugin files to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,9 @@ jobs:
             ```
             Then enable the Qoderian plugin in Obsidian settings.
 
-            `LICENSE` and `NOTICE` are attached for reference; the same notice is
-            embedded at the top of `main.js`.
+            The MIT license and attribution notice are embedded at the top of
+            `main.js`; see [LICENSE](https://github.com/${{ github.repository }}/blob/main/LICENSE)
+            and [NOTICE](https://github.com/${{ github.repository }}/blob/main/NOTICE) in the repository.
 
             ## What's Changed
             ${{ steps.changelog.outputs.notes }}
@@ -94,5 +95,3 @@ jobs:
             main.js
             manifest.json
             styles.css
-            LICENSE
-            NOTICE


### PR DESCRIPTION
Obsidian only downloads main.js, manifest.json, and styles.css, and the review bot flags LICENSE/NOTICE as unsupported extras. The MIT license and Claudian attribution stay embedded in the main.js banner and in the repository files, which the release notes now link to.

## Summary

- What changed?
- Why is it needed?

## Verification

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] `npm run release:check`
- [ ] `npm run audit:prod`
- [ ] Tested affected qodercli behavior against a real CLI when applicable

## Safety

- [ ] No credentials, private vault content, internal URLs, or personal paths are included
- [ ] User-visible changes are documented in `CHANGELOG.md`
