### PR TITLE
chore: surface underlying errors when session history fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ version with its date and start a fresh empty `[Unreleased]` above it.
 - Startup session restore no longer fails silently: when the tab
   layout, an individual tab, session metadata, or conversation history
   cannot be read, Qoderian now shows a single notice with the issue
-  count and logs per-stage details to the developer console.
+  count and logs per-stage details to the developer console, including
+  the underlying file error (such as a permission denial) for each
+  session history file that fails to load.
 
 ## [1.0.4] - 2026-08-12
 

--- a/src/qoder/history/qoder-conversation-history-service.ts
+++ b/src/qoder/history/qoder-conversation-history-service.ts
@@ -385,6 +385,7 @@ export class QoderConversationHistoryService {
     let missingSessionCount = 0;
     let errorCount = 0;
     let successCount = 0;
+    const loadErrors: string[] = [];
 
     const currentSessionId = isPendingFork
       ? state.forkSource!.sessionId
@@ -404,6 +405,7 @@ export class QoderConversationHistoryService {
 
       if (result.error) {
         errorCount++;
+        loadErrors.push(`${sessionId}: ${result.error}`);
         continue;
       }
 
@@ -415,7 +417,8 @@ export class QoderConversationHistoryService {
     if (errorCount > 0) {
       reportRestoreIssue(
         'history',
-        `Conversation "${conversation.id}": ${errorCount} of ${allSessionIds.length} session file(s) failed to load.`,
+        `Conversation "${conversation.id}": ${errorCount} of ${allSessionIds.length} session file(s) failed to load. `
+          + `Errors: ${loadErrors.join('; ')}`,
       );
     } else if (allSessionsMissing) {
       reportRestoreIssue(

--- a/tests/unit/qoder/history/qoder-conversation-history-service.test.ts
+++ b/tests/unit/qoder/history/qoder-conversation-history-service.test.ts
@@ -93,6 +93,8 @@ describe('QoderConversationHistoryService restore diagnostics', () => {
       stage: 'history',
       detail: expect.stringContaining('conv-1'),
     });
+    // The underlying error and session id must surface for diagnostics.
+    expect(issues[0].detail).toContain('sess-1: read failed');
   });
 
   it('reports a history issue when session files are missing on disk', async () => {


### PR DESCRIPTION
## Summary

- The startup restore report only counted failed session history files and discarded the underlying `readSDKSession` error, so user feedback could never reveal the root cause. The `history` stage report now appends each failing session id with its error (e.g. `Errors: <sessionId>: EPERM: operation not permitted, open '...'`).
- This change already proved its worth in the field: a diagnostic build with it let a user's console pinpoint an `EPERM` caused by endpoint security software blocking content access to `~/.qoder` session files — previously invisible behind the bare "failed to load" count.
- Extended the existing (still unreleased) restore-diagnostics changelog entry to mention the underlying file error; the user-facing Notice is unchanged, details go to the developer console only.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (3323 passed; new assertion covers the surfaced error detail)
- [x] `npm run build`
- [x] `npm run release:check`
- [x] `npm run audit:prod`
- [x] Tested affected qodercli behavior against a real CLI when applicable (a diagnostic build of this change was installed by an affected user; the console then showed the underlying `EPERM` error with the failing session path, confirming the enhancement works end to end)

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible changes are documented in `CHANGELOG.md`
