### PR TITLE
fix(chat): refresh external context on nested folder re-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ version with its date and start a fresh empty `[Unreleased]` above it.
 - Editing a queued message now replaces the composer content instead of
   appending to it.
 
+### Fixed
+
+- Re-selecting a folder in the external context picker that nests inside
+  (or contains) an existing entry now refreshes the selection: the
+  conflicting entry is replaced by the new pick (persistence inherited)
+  instead of being silently rejected, so the workspace folder visibly
+  updates after re-selection.
+
 ## [1.0.5] - 2026-08-18
 
 ### Added

--- a/src/core/context/external-context.ts
+++ b/src/core/context/external-context.ts
@@ -50,6 +50,31 @@ export function findConflictingPath(
   return null;
 }
 
+/**
+ * Returns every existing path that nests with the new path (either direction).
+ * Used by the folder picker's refresh semantics: re-selecting a nested folder
+ * replaces the conflicting entries instead of being rejected.
+ */
+export function findAllConflictingPaths(
+  newPath: string,
+  existingPaths: string[]
+): PathConflict[] {
+  const normalizedNew = normalizePathForComparison(newPath);
+  const conflicts: PathConflict[] = [];
+
+  for (const existing of existingPaths) {
+    const normalizedExisting = normalizePathForComparison(existing);
+
+    if (normalizedNew.startsWith(normalizedExisting + '/')) {
+      conflicts.push({ path: existing, type: 'parent' });
+    } else if (normalizedExisting.startsWith(normalizedNew + '/')) {
+      conflicts.push({ path: existing, type: 'child' });
+    }
+  }
+
+  return conflicts;
+}
+
 export function getFolderName(p: string): string {
   const normalized = normalizePathForDisplay(p);
   const segments = normalized.split('/');

--- a/src/features/chat/ui/input-toolbar.ts
+++ b/src/features/chat/ui/input-toolbar.ts
@@ -2,7 +2,8 @@ import { Notice, setIcon } from 'obsidian';
 import * as os from 'os';
 import * as path from 'path';
 
-import { filterValidPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../core/context/external-context';
+import type { PathConflict } from '../../../core/context/external-context';
+import { filterValidPaths, findAllConflictingPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../core/context/external-context';
 import { expandHomePath, normalizePathForFilesystem } from '../../../core/fs/path';
 import type {
   ManagedMcpServer,
@@ -261,14 +262,14 @@ export class ExternalContextSelector {
           return;
         }
 
-        // Check for nested/overlapping paths
-        const conflict = findConflictingPath(selectedPath, this.externalContextPaths);
-        if (conflict) {
-          new Notice(this.formatConflictMessage(selectedPath, conflict), 5000);
-          return;
+        // Re-selecting a nested folder refreshes the selection: conflicting
+        // entries are replaced by the new pick instead of being rejected.
+        const conflicts = findAllConflictingPaths(selectedPath, this.externalContextPaths);
+        if (conflicts.length > 0) {
+          this.replaceConflictingPaths(conflicts, selectedPath);
+        } else {
+          this.externalContextPaths = [...this.externalContextPaths, selectedPath];
         }
-
-        this.externalContextPaths = [...this.externalContextPaths, selectedPath];
         this.onChangeCallback?.(this.externalContextPaths);
         this.updateDisplay();
         this.renderDropdown();
@@ -276,6 +277,32 @@ export class ExternalContextSelector {
     } catch {
       new Notice('Unable to open folder picker.', 5000);
     }
+  }
+
+  /**
+   * Refresh semantics for the folder picker: entries nesting with the
+   * re-selected folder are replaced by it. Persistence (lock) is inherited
+   * when any replaced entry was persistent.
+   */
+  private replaceConflictingPaths(conflicts: PathConflict[], selectedPath: string): void {
+    const replaced = new Set(conflicts.map((conflict) => conflict.path));
+    const hadPersistent = conflicts.some((conflict) => this.persistentPaths.has(conflict.path));
+
+    this.externalContextPaths = [
+      ...this.externalContextPaths.filter((p) => !replaced.has(p)),
+      selectedPath,
+    ];
+
+    if (hadPersistent) {
+      for (const p of replaced) {
+        this.persistentPaths.delete(p);
+      }
+      this.persistentPaths.add(selectedPath);
+      this.onPersistenceChangeCallback?.([...this.persistentPaths]);
+    }
+
+    const replacedNames = conflicts.map((conflict) => this.shortenPath(conflict.path)).join(', ');
+    new Notice(`Replaced ${replacedNames} with "${this.shortenPath(selectedPath)}"`, 5000);
   }
 
   /** Formats a conflict error message for display. */

--- a/tests/unit/features/chat/ui/input-toolbar.external-context.test.ts
+++ b/tests/unit/features/chat/ui/input-toolbar.external-context.test.ts
@@ -14,6 +14,22 @@ jest.mock('obsidian', () => ({
 // Mock fs
 jest.mock('fs');
 
+// Mock electron remote dialog used by the native folder picker
+jest.mock(
+  'electron',
+  () => ({
+    remote: {
+      dialog: { showOpenDialog: jest.fn() },
+    },
+  }),
+  { virtual: true }
+);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const electronMock = require('electron') as {
+  remote: { dialog: { showOpenDialog: jest.Mock } };
+};
+
 // Mock callbacks
 function createMockCallbacks() {
   return {
@@ -532,6 +548,66 @@ describe('ExternalContextSelector', () => {
       expect(selector.getPersistentPaths()).toEqual([]);
       expect(selector.getExternalContexts()).toEqual([]);
       expect(onPersistenceChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('folder picker refresh semantics', () => {
+    const showOpenDialog = electronMock.remote.dialog.showOpenDialog;
+
+    async function pickFolder(paths: string[]): Promise<void> {
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: paths });
+      // openFolderPicker is private; exercised end-to-end here.
+      await (selector as unknown as { openFolderPicker(): Promise<void> }).openFolderPicker();
+    }
+
+    beforeEach(() => {
+      showOpenDialog.mockReset();
+    });
+
+    it('replaces a child entry when its parent is re-selected', async () => {
+      selector.addExternalContext('/vault/kb/qa');
+
+      await pickFolder(['/vault/kb']);
+
+      expect(selector.getExternalContexts()).toEqual(['/vault/kb']);
+    });
+
+    it('replaces a parent entry when a child is re-selected', async () => {
+      selector.addExternalContext('/vault/kb');
+
+      await pickFolder(['/vault/kb/qa']);
+
+      expect(selector.getExternalContexts()).toEqual(['/vault/kb/qa']);
+    });
+
+    it('inherits persistence from a replaced entry', async () => {
+      const onPersistenceChange = jest.fn();
+      selector.setOnPersistenceChange(onPersistenceChange);
+      selector.addExternalContext('/vault/kb');
+      selector.togglePersistence('/vault/kb');
+      onPersistenceChange.mockClear();
+
+      await pickFolder(['/vault/kb/qa']);
+
+      expect(selector.getExternalContexts()).toEqual(['/vault/kb/qa']);
+      expect(selector.getPersistentPaths()).toEqual(['/vault/kb/qa']);
+      expect(onPersistenceChange).toHaveBeenCalledWith(['/vault/kb/qa']);
+    });
+
+    it('still appends unrelated folders', async () => {
+      selector.addExternalContext('/vault/kb');
+
+      await pickFolder(['/other/docs']);
+
+      expect(selector.getExternalContexts()).toEqual(['/vault/kb', '/other/docs']);
+    });
+
+    it('still rejects exact duplicates', async () => {
+      selector.addExternalContext('/vault/kb');
+
+      await pickFolder(['/vault/kb']);
+
+      expect(selector.getExternalContexts()).toEqual(['/vault/kb']);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix "workspace folder doesn't update after re-selection" in the external context picker (`ExternalContextSelector.openFolderPicker`).
- Root cause (verified end-to-end on a real Obsidian via ComputerUse): re-selecting a folder that nests inside or contains an existing entry hit the conflict guard, showed a `Cannot add ...` Notice and left the list unchanged.
- New refresh semantics: conflicting entries are **replaced** by the re-selected folder, with a `Replaced "X" with "Y"` Notice; persistence (lock) is inherited when a replaced entry was persistent. Unrelated folders still append; exact duplicates still rejected with the existing Notice.
- Adds `findAllConflictingPaths()` in `src/core/context/external-context.ts` and 5 picker tests (electron remote dialog mocked).

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (3354 passed, incl. 5 new picker cases)
- [x] `npm run build`
- [x] `npm run release:check`
- [ ] `npm run audit:prod` (unchanged deps; ran on sibling branch this week)
- [x] Tested affected behavior against a real Obsidian: add `.../50-素材` → re-select parent `.../testObsidian` → entry replaced, Notice `Replaced ~/Documents/testObsidian/50-素材 with "~/Documents/testObsidian"`

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible changes are documented in `CHANGELOG.md`
