### PR TITLE
feat: inline reference chips in composer and message bubbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ version with its date and start a fresh empty `[Unreleased]` above it.
 - Drag notes or folders from the Obsidian file explorer into the chat
   composer: they are inserted as `@note` / `@folder/` context mentions at
   the caret, with duplicates skipped and a drop overlay while dragging.
+- `@file` / `@folder/` references render as inline chips in the composer
+  and in sent message bubbles; chips open with Cmd/Ctrl-click and delete
+  atomically with Backspace/Delete.
 
 ### Changed
 
@@ -30,6 +33,15 @@ version with its date and start a fresh empty `[Unreleased]` above it.
   (or clearing the queue) restores the normal one-per-turn drain.
 - Editing a queued message now replaces the composer content instead of
   appending to it.
+
+### Fixed
+
+- Mention chips in message bubbles now resolve paths containing spaces
+  (longest-match vault verification) instead of truncating at the first
+  space.
+- Dropping a vault note or folder into the composer no longer pastes the
+  raw `obsidian://open` URI next to the mention, and the inserted mention
+  chipifies like dropdown insertions.
 
 ## [1.0.5] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ version with its date and start a fresh empty `[Unreleased]` above it.
   the caret, with duplicates skipped and a drop overlay while dragging.
 - `@file` / `@folder/` references render as inline chips in the composer
   and in sent message bubbles; clicking a chip opens the note (both
-  surfaces), and Backspace/Delete removes a composer chip atomically.
+  surfaces), and a composer chip can be removed via its × button or
+  atomically with Backspace/Delete.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ version with its date and start a fresh empty `[Unreleased]` above it.
   composer: they are inserted as `@note` / `@folder/` context mentions at
   the caret, with duplicates skipped and a drop overlay while dragging.
 - `@file` / `@folder/` references render as inline chips in the composer
-  and in sent message bubbles; chips open with Cmd/Ctrl-click and delete
-  atomically with Backspace/Delete.
+  and in sent message bubbles; clicking a chip opens the note (both
+  surfaces), and Backspace/Delete removes a composer chip atomically.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@codemirror/commands": "^6.11.0",
         "@codemirror/state": "^6.5.0",
         "@codemirror/view": "^6.38.6",
         "@modelcontextprotocol/sdk": "~1.30.0",
@@ -573,6 +574,41 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.11.0.tgz",
+      "integrity": "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/commands/node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
     },
     "node_modules/@codemirror/state": {
       "version": "6.5.0",
@@ -2044,6 +2080,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@marijn/find-cluster-break": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.11.0",
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.38.6",
     "@modelcontextprotocol/sdk": "~1.30.0",

--- a/src/features/chat/rendering/message-renderer.ts
+++ b/src/features/chat/rendering/message-renderer.ts
@@ -23,7 +23,8 @@ import {
   normalizeMathDelimitersForObsidian,
 } from '../../../shared/markdown/markdown-math';
 import { replaceMentionTokensWithHtml } from '../../../shared/markdown/mention-chip';
-import { openVaultEntry } from '../../../shared/obsidian/compat';
+import type { ReferenceChipKind } from '../../../shared/mention/types';
+import { openReferenceChip } from '../../../shared/obsidian/compat';
 import { formatConversationDirectoryTitle } from '../utils/conversation-directory-title';
 import { findRewindContext } from '../utils/rewind';
 import {
@@ -734,8 +735,9 @@ export class MessageRenderer {
       }
       chip.addEventListener('click', () => {
         const path = chip.dataset.path;
-        if (!path) return;
-        openVaultEntry(this.app, path);
+        const kind = chip.dataset.kind as ReferenceChipKind | undefined;
+        if (!path || !kind) return;
+        openReferenceChip(this.app, kind, path);
       });
     });
   }

--- a/src/features/chat/rendering/message-renderer.ts
+++ b/src/features/chat/rendering/message-renderer.ts
@@ -22,6 +22,8 @@ import {
   escapeMathDelimitersForStreaming,
   normalizeMathDelimitersForObsidian,
 } from '../../../shared/markdown/markdown-math';
+import { replaceMentionTokensWithHtml } from '../../../shared/markdown/mention-chip';
+import { openVaultEntry } from '../../../shared/obsidian/compat';
 import { formatConversationDirectoryTitle } from '../utils/conversation-directory-title';
 import { findRewindContext } from '../utils/rewind';
 import {
@@ -34,6 +36,8 @@ import { renderStoredWriteEdit } from './write-edit-renderer';
 
 export interface RenderContentOptions {
   deferMath?: boolean;
+  /** Render `@path` tokens that resolve in the vault as reference chips. */
+  userReferenceChips?: boolean;
 }
 
 export type RenderContentFn = (
@@ -135,7 +139,7 @@ export class MessageRenderer {
       const textToShow = this.getUserMessageTextToShow(msg);
       if (textToShow) {
         const textEl = contentEl.createDiv({ cls: 'qoderian-text-block' });
-        void this.renderContent(textEl, textToShow);
+        void this.renderContent(textEl, textToShow, { userReferenceChips: true });
         this.addUserCopyButton(msgEl, textToShow);
         this.applyTocTitle(msgEl, textToShow);
       }
@@ -169,7 +173,7 @@ export class MessageRenderer {
     const textToShow = this.getUserMessageTextToShow(msg);
     if (textToShow) {
       const textEl = contentEl.createDiv({ cls: 'qoderian-text-block' });
-      void this.renderContent(textEl, textToShow);
+      void this.renderContent(textEl, textToShow, { userReferenceChips: true });
       this.applyTocTitle(msgEl, textToShow);
     } else {
       msgEl.removeAttribute('data-toc-title');
@@ -270,7 +274,7 @@ export class MessageRenderer {
       const textToShow = this.getUserMessageTextToShow(msg);
       if (textToShow) {
         const textEl = contentEl.createDiv({ cls: 'qoderian-text-block' });
-        void this.renderContent(textEl, textToShow);
+        void this.renderContent(textEl, textToShow, { userReferenceChips: true });
         this.addUserCopyButton(msgEl, textToShow);
         this.applyTocTitle(msgEl, textToShow);
       }
@@ -641,11 +645,14 @@ export class MessageRenderer {
         ? escapeMathDelimitersForStreaming(normalizedMarkdown)
         : normalizedMarkdown;
       // Normalize embeds before MarkdownRenderer consumes them.
-      const processedMarkdown = replaceImageEmbedsWithHtml(
+      let processedMarkdown = replaceImageEmbedsWithHtml(
         renderMarkdown,
         this.app,
         { mediaFolder: this.plugin.settings.mediaFolder }
       );
+      if (options?.userReferenceChips) {
+        processedMarkdown = replaceMentionTokensWithHtml(processedMarkdown, this.app);
+      }
       await MarkdownRenderer.render(
         this.app,
         processedMarkdown,
@@ -653,6 +660,10 @@ export class MessageRenderer {
         '',
         this.component
       );
+
+      if (options?.userReferenceChips) {
+        this.enhanceMentionChips(el);
+      }
 
       // Wrap pre elements and move buttons outside scroll area
       el.querySelectorAll('pre').forEach((pre) => {
@@ -709,6 +720,24 @@ export class MessageRenderer {
         text: 'Failed to render message content.',
       });
     }
+  }
+
+  /**
+   * Fills chip icons and click-to-open behavior on rendered mention chips.
+   * The HTML pass only carries data attributes; DOM APIs finish the job.
+   */
+  private enhanceMentionChips(el: HTMLElement): void {
+    el.querySelectorAll<HTMLElement>('.qoderian-msg-reference').forEach((chip) => {
+      const iconEl = chip.querySelector<HTMLElement>('.qoderian-composer-reference-icon');
+      if (iconEl) {
+        setIcon(iconEl, chip.dataset.kind === 'folder' ? 'folder' : 'file-text');
+      }
+      chip.addEventListener('click', () => {
+        const path = chip.dataset.path;
+        if (!path) return;
+        openVaultEntry(this.app, path);
+      });
+    });
   }
 
   // ============================================

--- a/src/features/chat/tabs/tab-lifecycle.ts
+++ b/src/features/chat/tabs/tab-lifecycle.ts
@@ -40,6 +40,8 @@ export async function destroyTab(tab: TabData): Promise<void> {
   tab.ui.fileContextManager?.destroy();
   tab.ui.vaultDropController?.destroy();
   tab.ui.vaultDropController = null;
+  tab.ui.composerBridge?.destroy();
+  tab.ui.composerBridge = null;
   tab.ui.modelSelector?.destroy();
   tab.ui.modelSelector = null;
   tab.ui.slashCommandDropdown?.destroy();

--- a/src/features/chat/tabs/tab.ts
+++ b/src/features/chat/tabs/tab.ts
@@ -291,7 +291,11 @@ function initializeContextManagers(tab: TabData, plugin: QoderianPlugin): void {
 
   // Vault file/folder drop - must attach before ImageContextManager so vault
   // drags are claimed before the image drop handlers run.
-  tab.ui.vaultDropController = new VaultDropController(app, dom.inputWrapper, dom.inputEl);
+  tab.ui.vaultDropController = new VaultDropController(app, dom.inputWrapper, dom.inputEl, {
+    onInsertReference: (reference) => {
+      tab.ui.fileContextManager?.registerComposerReference(reference);
+    },
+  });
 
   // Image context manager - drag/drop uses inputContainerEl, preview in contextRowEl
   tab.ui.imageContextManager = new ImageContextManager(

--- a/src/features/chat/tabs/tab.ts
+++ b/src/features/chat/tabs/tab.ts
@@ -14,6 +14,7 @@ import {
   SlashCommandDropdown,
   toSlashCommandDropdownEntries,
 } from '../../../shared/components/slash-command-dropdown';
+import { openVaultEntry } from '../../../shared/obsidian/compat';
 import { BrowserSelectionController } from '../controllers/browser-selection-controller';
 import { CanvasSelectionController } from '../controllers/canvas-selection-controller';
 import { ContextRowOverflowController } from '../controllers/context-row-overflow';
@@ -28,6 +29,7 @@ import { BangBashService } from '../services/bang-bash-service';
 import { SubagentManager } from '../services/subagent-manager';
 import { ChatState } from '../state/chat-state';
 import { BangBashModeManager as BangBashModeManagerClass } from '../ui/bang-bash-mode-manager';
+import { ComposerBridge } from '../ui/composer/composer-bridge';
 import { ComposerActionButton } from '../ui/composer-action-button';
 import { FileContextManager } from '../ui/file-context/file-context-manager';
 import { ImageContextManager } from '../ui/image-context';
@@ -147,6 +149,7 @@ export function createTab(options: TabCreateOptions): TabData {
       titleGenerationService: null,
     },
     ui: {
+      composerBridge: null,
       fileContextManager: null,
       imageContextManager: null,
       vaultDropController: null,
@@ -255,6 +258,14 @@ function initializeContextManagers(tab: TabData, plugin: QoderianPlugin): void {
   const { dom } = tab;
   const app = plugin.app;
 
+  // Live composer bridge - must exist before other input consumers so its
+  // textarea interceptors cover every later listener/programmatic access.
+  tab.ui.composerBridge = new ComposerBridge(dom.inputEl, {
+    onOpenReference: (reference) => {
+      openVaultEntry(app, reference.path);
+    },
+  });
+
   // File context manager - chips in contextRowEl, dropdown in inputContainerEl
   tab.ui.fileContextManager = new FileContextManager(
     app,
@@ -268,6 +279,9 @@ function initializeContextManagers(tab: TabData, plugin: QoderianPlugin): void {
         tab.controllers.canvasSelectionController?.updateContextRowVisibility();
         autoResizeTextarea(dom.inputEl);
         tab.renderer?.scrollToBottomIfNeeded();
+      },
+      onReferencesChanged: (references) => {
+        tab.ui.composerBridge?.setReferences(references);
       },
       getExternalContexts: () => tab.ui.externalContextSelector?.getExternalContexts() || [],
     },

--- a/src/features/chat/tabs/tab.ts
+++ b/src/features/chat/tabs/tab.ts
@@ -14,7 +14,7 @@ import {
   SlashCommandDropdown,
   toSlashCommandDropdownEntries,
 } from '../../../shared/components/slash-command-dropdown';
-import { openVaultEntry } from '../../../shared/obsidian/compat';
+import { openReferenceChip } from '../../../shared/obsidian/compat';
 import { BrowserSelectionController } from '../controllers/browser-selection-controller';
 import { CanvasSelectionController } from '../controllers/canvas-selection-controller';
 import { ContextRowOverflowController } from '../controllers/context-row-overflow';
@@ -262,7 +262,7 @@ function initializeContextManagers(tab: TabData, plugin: QoderianPlugin): void {
   // textarea interceptors cover every later listener/programmatic access.
   tab.ui.composerBridge = new ComposerBridge(dom.inputEl, {
     onOpenReference: (reference) => {
-      openVaultEntry(app, reference.path);
+      openReferenceChip(app, reference.kind, reference.path);
     },
   });
 

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -15,6 +15,7 @@ import type { MessageRenderer } from '../rendering/message-renderer';
 import type { SubagentManager } from '../services/subagent-manager';
 import type { ChatState } from '../state/chat-state';
 import type { BangBashModeManager } from '../ui/bang-bash-mode-manager';
+import type { ComposerBridge } from '../ui/composer/composer-bridge';
 import type { ComposerActionButton } from '../ui/composer-action-button';
 import type { FileContextManager } from '../ui/file-context/file-context-manager';
 import type { ImageContextManager } from '../ui/image-context';
@@ -115,6 +116,8 @@ export interface TabServices {
  * UI components managed per-tab.
  */
 export interface TabUIComponents {
+  /** Bridges the legacy textarea with the CodeMirror live composer. */
+  composerBridge: ComposerBridge | null;
   fileContextManager: FileContextManager | null;
   imageContextManager: ImageContextManager | null;
   vaultDropController: VaultDropController | null;

--- a/src/features/chat/ui/composer/composer-bridge.ts
+++ b/src/features/chat/ui/composer/composer-bridge.ts
@@ -1,0 +1,238 @@
+import type { ComposerReference } from './composer-reference';
+import { LiveComposer } from './live-composer';
+
+export interface ComposerBridgeOptions {
+  onOpenReference?: (reference: ComposerReference) => void;
+}
+
+type NativePropertyDescriptors = {
+  value: PropertyDescriptor;
+  selectionStart: PropertyDescriptor;
+  selectionEnd: PropertyDescriptor;
+  placeholder: PropertyDescriptor;
+};
+
+function getNativePropertyDescriptors(): NativePropertyDescriptors {
+  const descriptors = {
+    value: Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value'),
+    selectionStart: Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'selectionStart'),
+    selectionEnd: Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'selectionEnd'),
+    placeholder: Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'placeholder'),
+  };
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    if (!descriptor) {
+      throw new Error(`HTMLTextAreaElement.prototype.${key} descriptor is unavailable`);
+    }
+  }
+  return descriptors as NativePropertyDescriptors;
+}
+
+/**
+ * Keeps a hidden textarea and a {@link LiveComposer} in lockstep.
+ *
+ * The textarea remains the wiring target for every existing input consumer
+ * (mention dropdown, keyboard shortcuts, draft persistence, programmatic
+ * writes). The bridge intercepts property writes and events so those
+ * consumers keep working unchanged while the user edits in CodeMirror:
+ *
+ * - Programmatic writes to `value`/`selectionStart`/`selectionEnd`/
+ *   `placeholder` and `focus()` calls are mirrored into the composer.
+ * - Composer edits are written back to the textarea and announced with a
+ *   synthetic `input` event.
+ * - Composer `keydown`/`paste` are forwarded to the textarea so listeners
+ *   (send shortcuts, image paste) still observe them.
+ */
+export class ComposerBridge {
+  private readonly sourceEl: HTMLTextAreaElement;
+  private readonly hostEl: HTMLElement;
+  readonly composer: LiveComposer;
+
+  private syncing = false;
+  private destroyed = false;
+  private readonly descriptors: NativePropertyDescriptors;
+  private readonly originalFocus: HTMLTextAreaElement['focus'];
+  private readonly originalSetSelectionRange: HTMLTextAreaElement['setSelectionRange'];
+
+  private readonly handleComposerPaste = (event: ClipboardEvent): void => {
+    const EventConstructor = this.sourceEl.ownerDocument.defaultView?.Event ?? Event;
+    const forwardedEvent = new EventConstructor('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(forwardedEvent, 'clipboardData', { value: event.clipboardData });
+    this.sourceEl.dispatchEvent(forwardedEvent);
+    if (forwardedEvent.defaultPrevented) event.preventDefault();
+  };
+
+  private readonly handleComposerKeydown = (event: KeyboardEvent): boolean => {
+    this.syncSelectionToSource(this.composer.selectionStart, this.composer.selectionEnd);
+    const KeyboardEventConstructor = this.sourceEl.ownerDocument.defaultView?.KeyboardEvent ?? KeyboardEvent;
+    const forwardedEvent = new KeyboardEventConstructor('keydown', {
+      key: event.key,
+      code: event.code,
+      altKey: event.altKey,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey,
+      repeat: event.repeat,
+      isComposing: event.isComposing,
+      bubbles: true,
+      cancelable: true,
+    });
+    this.sourceEl.dispatchEvent(forwardedEvent);
+    if (forwardedEvent.defaultPrevented) {
+      event.preventDefault();
+      this.syncFromSource();
+      return true;
+    }
+    return false;
+  };
+
+  constructor(sourceEl: HTMLTextAreaElement, options: ComposerBridgeOptions = {}) {
+    this.sourceEl = sourceEl;
+    this.descriptors = getNativePropertyDescriptors();
+    this.originalFocus = sourceEl.focus.bind(sourceEl);
+    this.originalSetSelectionRange = sourceEl.setSelectionRange.bind(sourceEl);
+
+    const parentEl = sourceEl.parentElement;
+    this.hostEl = sourceEl.createDiv({ cls: 'qoderian-live-composer-host' });
+    parentEl?.insertBefore(this.hostEl, sourceEl);
+    sourceEl.addClass('qoderian-composer-source');
+
+    this.composer = new LiveComposer(this.hostEl, {
+      initialValue: sourceEl.value,
+      placeholder: sourceEl.placeholder,
+      onKeydown: this.handleComposerKeydown,
+      onOpenReference: options.onOpenReference,
+      onDocChanged: (value) => this.syncToSource(value),
+      onSelectionChange: (from, to) => this.syncSelectionToSource(from, to),
+    });
+
+    sourceEl.addEventListener('input', this.handleSourceInput);
+    this.composer.dom.addEventListener('paste', this.handleComposerPaste);
+
+    this.installSourceInterceptors();
+  }
+
+  setReferences(references: readonly ComposerReference[]): void {
+    this.composer.setReferences(references);
+  }
+
+  /** Pulls value, selection, and placeholder from the textarea into the composer. */
+  syncFromSource(): void {
+    if (this.destroyed) return;
+    this.composer.value = this.sourceEl.value;
+    this.composer.setSelectionRange(this.sourceEl.selectionStart, this.sourceEl.selectionEnd);
+    this.composer.setPlaceholder(this.sourceEl.placeholder);
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+
+    this.sourceEl.removeEventListener('input', this.handleSourceInput);
+    this.composer.dom.removeEventListener('paste', this.handleComposerPaste);
+
+    this.uninstallSourceInterceptors();
+    this.sourceEl.removeClass('qoderian-composer-source');
+    this.composer.destroy();
+    this.hostEl.remove();
+  }
+
+  private readonly handleSourceInput = (): void => {
+    if (this.syncing || this.destroyed) return;
+    this.syncFromSource();
+  };
+
+  private installSourceInterceptors(): void {
+    const nativeValueGet = this.descriptors.value.get!;
+    const nativeValueSet = this.descriptors.value.set!;
+    const nativeSelectionStartGet = this.descriptors.selectionStart.get!;
+    const nativeSelectionStartSet = this.descriptors.selectionStart.set!;
+    const nativeSelectionEndGet = this.descriptors.selectionEnd.get!;
+    const nativeSelectionEndSet = this.descriptors.selectionEnd.set!;
+    const nativePlaceholderGet = this.descriptors.placeholder.get!;
+    const nativePlaceholderSet = this.descriptors.placeholder.set!;
+    const sourceEl = this.sourceEl;
+
+    Object.defineProperty(sourceEl, 'value', {
+      configurable: true,
+      get: () => nativeValueGet.call(sourceEl),
+      set: (value: string) => {
+        nativeValueSet.call(sourceEl, value);
+        this.syncComposerFromSource();
+      },
+    });
+    Object.defineProperty(sourceEl, 'selectionStart', {
+      configurable: true,
+      get: () => nativeSelectionStartGet.call(sourceEl),
+      set: (position: number | null) => {
+        nativeSelectionStartSet.call(sourceEl, position);
+        this.syncComposerSelectionFromSource();
+      },
+    });
+    Object.defineProperty(sourceEl, 'selectionEnd', {
+      configurable: true,
+      get: () => nativeSelectionEndGet.call(sourceEl),
+      set: (position: number | null) => {
+        nativeSelectionEndSet.call(sourceEl, position);
+        this.syncComposerSelectionFromSource();
+      },
+    });
+    Object.defineProperty(sourceEl, 'placeholder', {
+      configurable: true,
+      get: () => nativePlaceholderGet.call(sourceEl),
+      set: (value: string) => {
+        nativePlaceholderSet.call(sourceEl, value);
+        if (!this.destroyed) this.composer.setPlaceholder(value);
+      },
+    });
+
+    sourceEl.focus = (): void => {
+      this.syncFromSource();
+      this.composer.focus();
+    };
+    sourceEl.setSelectionRange = (start: number, end: number): void => {
+      this.originalSetSelectionRange(start, end);
+      this.syncComposerSelectionFromSource();
+    };
+  }
+
+  private uninstallSourceInterceptors(): void {
+    const sourceEl = this.sourceEl;
+    for (const key of ['value', 'selectionStart', 'selectionEnd', 'placeholder'] as const) {
+      const descriptor = this.descriptors[key];
+      Object.defineProperty(sourceEl, key, descriptor);
+    }
+    sourceEl.focus = this.originalFocus;
+    sourceEl.setSelectionRange = this.originalSetSelectionRange;
+  }
+
+  /** Mirrors a programmatic textarea value write into the composer. */
+  private syncComposerFromSource(): void {
+    if (this.destroyed) return;
+    this.composer.value = this.sourceEl.value;
+  }
+
+  private syncComposerSelectionFromSource(): void {
+    if (this.destroyed) return;
+    this.composer.setSelectionRange(this.sourceEl.selectionStart, this.sourceEl.selectionEnd);
+  }
+
+  /** Writes a composer edit back into the textarea and announces it. */
+  private syncToSource(value: string): void {
+    if (this.destroyed) return;
+    this.syncing = true;
+    try {
+      this.descriptors.value.set!.call(this.sourceEl, value);
+      this.syncSelectionToSource(this.composer.selectionStart, this.composer.selectionEnd);
+      const EventConstructor = this.sourceEl.ownerDocument.defaultView?.Event ?? Event;
+      this.sourceEl.dispatchEvent(new EventConstructor('input', { bubbles: true }));
+    } finally {
+      this.syncing = false;
+    }
+  }
+
+  /** Pushes the composer selection to the textarea using the native method. */
+  private syncSelectionToSource(from: number, to: number): void {
+    if (this.destroyed) return;
+    this.originalSetSelectionRange(from, to);
+  }
+}

--- a/src/features/chat/ui/composer/composer-reference.ts
+++ b/src/features/chat/ui/composer/composer-reference.ts
@@ -7,7 +7,9 @@
  * source of truth that gets sent to the agent.
  */
 
-export type ComposerReferenceKind = 'file' | 'folder';
+import type { ReferenceChipKind } from '../../../../shared/mention/types';
+
+export type ComposerReferenceKind = ReferenceChipKind;
 
 export interface ComposerReference {
   /** Full token text including the leading `@`; folders keep the trailing slash. */

--- a/src/features/chat/ui/composer/composer-reference.ts
+++ b/src/features/chat/ui/composer/composer-reference.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure reference-matching logic for the live composer.
+ *
+ * A reference is a token inserted into the composer text by the mention
+ * dropdown (e.g. `@folder/note.md` or `@folder/`). The composer renders
+ * matching tokens as inline chips, while the text itself remains the single
+ * source of truth that gets sent to the agent.
+ */
+
+export type ComposerReferenceKind = 'file' | 'folder';
+
+export interface ComposerReference {
+  /** Full token text including the leading `@`; folders keep the trailing slash. */
+  token: string;
+  /** Path used for the chip label and open actions. */
+  path: string;
+  kind: ComposerReferenceKind;
+}
+
+export interface ComposerReferenceRange {
+  reference: ComposerReference;
+  from: number;
+  to: number;
+}
+
+export const COMPOSER_REFERENCE_LABEL_MAX_LENGTH = 20;
+
+// Label formatting is shared with message-bubble chips; re-export for composer consumers.
+export { formatReferenceLabel } from '../../../../shared/markdown/mention-chip';
+
+function isTokenBoundary(text: string, index: number): boolean {
+  return index <= 0 || index >= text.length || /\s/.test(text[index]);
+}
+
+/**
+ * Finds every occurrence of a known reference token in the text.
+ * Occurrences only count when surrounded by token boundaries (whitespace or
+ * the start/end of the text), so a token inside a longer word is ignored.
+ */
+export function findReferenceRanges(
+  text: string,
+  references: readonly ComposerReference[],
+): ComposerReferenceRange[] {
+  const ranges: ComposerReferenceRange[] = [];
+  for (const reference of references) {
+    if (!reference.token) continue;
+    let from = text.indexOf(reference.token);
+    while (from >= 0) {
+      const to = from + reference.token.length;
+      if (isTokenBoundary(text, from - 1) && isTokenBoundary(text, to)) {
+        ranges.push({ reference, from, to });
+      }
+      from = text.indexOf(reference.token, from + reference.token.length);
+    }
+  }
+  ranges.sort((a, b) => a.from - b.from || a.to - b.to);
+  return ranges;
+}
+
+export interface AtomicDeleteQuery {
+  key: 'Backspace' | 'Delete';
+  selectionFrom: number;
+  selectionTo: number;
+}
+
+/**
+ * Returns the reference range an atomic delete should remove as a whole,
+ * or null when the deletion does not touch a reference chip.
+ *
+ * - Empty selection: Backspace removes the chip ending at the caret;
+ *   Delete removes the chip starting at the caret.
+ * - Range selection: any chip overlapping the selection is removed.
+ */
+export function findAtomicDeleteRange(
+  text: string,
+  references: readonly ComposerReference[],
+  query: AtomicDeleteQuery,
+): ComposerReferenceRange | null {
+  const { key, selectionFrom, selectionTo } = query;
+  const selectionEmpty = selectionFrom === selectionTo;
+  return findReferenceRanges(text, references).find(range => {
+    if (!selectionEmpty) {
+      return selectionFrom < range.to && selectionTo > range.from;
+    }
+    return key === 'Backspace'
+      ? selectionFrom === range.to
+      : selectionFrom === range.from;
+  }) ?? null;
+}

--- a/src/features/chat/ui/composer/live-composer.ts
+++ b/src/features/chat/ui/composer/live-composer.ts
@@ -61,7 +61,7 @@ class ReferenceWidget extends WidgetType {
   }
 
   toDOM(view: EditorView): HTMLElement {
-    const { reference, from, to } = this.range;
+    const { reference } = this.range;
     const element = createDetachedElement(view, 'span');
     const icon = createDetachedElement(view, 'span');
     const label = createDetachedElement(view, 'span');
@@ -76,14 +76,10 @@ class ReferenceWidget extends WidgetType {
     label.classList.add('qoderian-composer-reference-label');
     label.textContent = formatReferenceLabel(reference.path);
     element.append(icon, label);
+    // Plain click opens the reference, same as message-bubble chips.
     element.addEventListener('click', (event) => {
       event.preventDefault();
-      if (event.metaKey || event.ctrlKey) {
-        this.onOpenReference?.(reference);
-        return;
-      }
-      view.dispatch({ selection: EditorSelection.range(from, to) });
-      view.focus();
+      this.onOpenReference?.(reference);
     });
     return element;
   }

--- a/src/features/chat/ui/composer/live-composer.ts
+++ b/src/features/chat/ui/composer/live-composer.ts
@@ -1,0 +1,292 @@
+import { defaultKeymap,history, historyKeymap } from '@codemirror/commands';
+import { Compartment, EditorSelection, EditorState, Prec, StateEffect } from '@codemirror/state';
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  keymap,
+  placeholder,
+  type PluginValue,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from '@codemirror/view';
+import { setIcon } from 'obsidian';
+
+import {
+  calculateTextareaMaxHeight,
+  calculateTextareaMinHeight,
+  TEXTAREA_BASE_MIN_HEIGHT,
+} from '../textarea-resize';
+import {
+  type ComposerReference,
+  type ComposerReferenceRange,
+  findAtomicDeleteRange,
+  findReferenceRanges,
+  formatReferenceLabel,
+} from './composer-reference';
+
+const refreshReferencesEffect = StateEffect.define<void>();
+
+/**
+ * CodeMirror widgets must return detached elements from `toDOM()`. Creating
+ * through the owning editor keeps pop-out windows on the correct document;
+ * detaching immediately leaves the widget ready for CodeMirror to mount.
+ */
+function createDetachedElement<K extends keyof HTMLElementTagNameMap>(
+  view: EditorView,
+  tag: K,
+): HTMLElementTagNameMap[K] {
+  const element = view.dom.createEl(tag);
+  element.detach();
+  return element;
+}
+
+/** Renders one composer reference token as an inline chip. */
+class ReferenceWidget extends WidgetType {
+  constructor(
+    private readonly range: ComposerReferenceRange,
+    private readonly selected: boolean,
+    private readonly onOpenReference?: (reference: ComposerReference) => void,
+  ) {
+    super();
+  }
+
+  eq(other: ReferenceWidget): boolean {
+    return this.range.reference.token === other.range.reference.token
+      && this.range.reference.kind === other.range.reference.kind
+      && this.range.from === other.range.from
+      && this.range.to === other.range.to
+      && this.selected === other.selected;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const { reference, from, to } = this.range;
+    const element = createDetachedElement(view, 'span');
+    const icon = createDetachedElement(view, 'span');
+    const label = createDetachedElement(view, 'span');
+
+    element.classList.add('qoderian-composer-reference');
+    element.classList.toggle('qoderian-composer-reference--selected', this.selected);
+    element.dataset.path = reference.path;
+    element.dataset.kind = reference.kind;
+    element.title = reference.token;
+    icon.classList.add('qoderian-composer-reference-icon');
+    setIcon(icon, reference.kind === 'folder' ? 'folder' : 'file-text');
+    label.classList.add('qoderian-composer-reference-label');
+    label.textContent = formatReferenceLabel(reference.path);
+    element.append(icon, label);
+    element.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (event.metaKey || event.ctrlKey) {
+        this.onOpenReference?.(reference);
+        return;
+      }
+      view.dispatch({ selection: EditorSelection.range(from, to) });
+      view.focus();
+    });
+    return element;
+  }
+
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+interface DecorationPluginOptions {
+  getReferences: () => readonly ComposerReference[];
+  onOpenReference?: (reference: ComposerReference) => void;
+}
+
+function createReferenceDecorationPlugin(options: DecorationPluginOptions) {
+  return ViewPlugin.fromClass(class implements PluginValue {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = this.buildDecorations(view);
+    }
+
+    update(update: ViewUpdate): void {
+      const refreshRequested = update.transactions.some(transaction => (
+        transaction.effects.some(effect => effect.is(refreshReferencesEffect))
+      ));
+      if (update.docChanged || update.selectionSet || update.viewportChanged || refreshRequested) {
+        this.decorations = this.buildDecorations(update.view);
+      }
+    }
+
+    private buildDecorations(view: EditorView): DecorationSet {
+      const text = view.state.doc.toString();
+      const selection = view.state.selection.main;
+      const ranges = findReferenceRanges(text, options.getReferences());
+
+      return Decoration.set(ranges.map(range => Decoration.replace({
+        widget: new ReferenceWidget(
+          range,
+          selection.from === range.from && selection.to === range.to,
+          options.onOpenReference,
+        ),
+      }).range(range.from, range.to)), true);
+    }
+  }, {
+    decorations: value => value.decorations,
+  });
+}
+
+export interface LiveComposerOptions {
+  initialValue?: string;
+  placeholder?: string;
+  /** Intercepted before CodeMirror handles the key; return true to consume. */
+  onKeydown?: (event: KeyboardEvent) => boolean | void;
+  onOpenReference?: (reference: ComposerReference) => void;
+  onDocChanged?: (value: string) => void;
+  onSelectionChange?: (from: number, to: number) => void;
+}
+
+/**
+ * CodeMirror-backed composer surface. The document stays plain text
+ * (`@path` tokens included); reference tokens are decorated as inline chips.
+ */
+export class LiveComposer {
+  private readonly view: EditorView;
+  private readonly placeholderCompartment = new Compartment();
+  private references: readonly ComposerReference[] = [];
+
+  constructor(parentEl: HTMLElement, private readonly options: LiveComposerOptions = {}) {
+    const state = EditorState.create({
+      doc: options.initialValue ?? '',
+      extensions: [
+        history(),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        EditorView.lineWrapping,
+        EditorView.editorAttributes.of({ class: 'qoderian-live-composer' }),
+        this.placeholderCompartment.of(placeholder(options.placeholder ?? '')),
+        createReferenceDecorationPlugin({
+          getReferences: () => this.references,
+          onOpenReference: options.onOpenReference,
+        }),
+        Prec.highest(EditorView.domEventHandlers({
+          keydown: (event) => this.handleKeydown(event),
+        })),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            this.updateHeight();
+            this.options.onDocChanged?.(update.state.doc.toString());
+          }
+          if (update.selectionSet) {
+            const selection = update.state.selection.main;
+            this.options.onSelectionChange?.(selection.from, selection.to);
+          }
+        }),
+      ],
+    });
+    this.view = new EditorView({ state, parent: parentEl });
+    this.updateHeight();
+  }
+
+  get dom(): HTMLElement {
+    return this.view.dom;
+  }
+
+  get contentDOM(): HTMLElement {
+    return this.view.contentDOM;
+  }
+
+  get value(): string {
+    return this.view.state.doc.toString();
+  }
+
+  set value(value: string) {
+    if (value === this.value) return;
+    this.view.dispatch({
+      changes: { from: 0, to: this.view.state.doc.length, insert: value },
+    });
+  }
+
+  get selectionStart(): number {
+    return this.view.state.selection.main.from;
+  }
+
+  get selectionEnd(): number {
+    return this.view.state.selection.main.to;
+  }
+
+  setSelectionRange(start: number, end: number): void {
+    this.view.dispatch({
+      selection: EditorSelection.range(start, end),
+    });
+  }
+
+  setReferences(references: readonly ComposerReference[]): void {
+    this.references = references;
+    this.view.dispatch({ effects: refreshReferencesEffect.of() });
+  }
+
+  setPlaceholder(value: string): void {
+    this.view.dispatch({
+      effects: this.placeholderCompartment.reconfigure(placeholder(value)),
+    });
+  }
+
+  focus(): void {
+    this.view.focus();
+  }
+
+  destroy(): void {
+    this.view.destroy();
+  }
+
+  private handleKeydown(event: KeyboardEvent): boolean {
+    if (this.options.onKeydown?.(event) === true || event.defaultPrevented) return true;
+
+    if ((event.key === 'Backspace' || event.key === 'Delete') && this.deleteAtomicReference(event.key)) {
+      event.preventDefault();
+      return true;
+    }
+
+    return false;
+  }
+
+  /** Removes a reference chip (and its token) in one keystroke. */
+  private deleteAtomicReference(key: 'Backspace' | 'Delete'): boolean {
+    const selection = this.view.state.selection.main;
+    const target = findAtomicDeleteRange(this.value, this.references, {
+      key,
+      selectionFrom: selection.from,
+      selectionTo: selection.to,
+    });
+    if (!target) return false;
+
+    this.view.dispatch({
+      changes: { from: target.from, to: target.to, insert: '' },
+      selection: { anchor: target.from },
+      scrollIntoView: true,
+    });
+    return true;
+  }
+
+  /**
+   * Mirrors the textarea auto-resize contract: grows with content, capped at
+   * a share of the view height. Metrics come from the CodeMirror scroller.
+   */
+  private updateHeight(): void {
+    const viewHeight = this.view.dom.closest('.qoderian-container')?.clientHeight
+      ?? this.view.dom.ownerDocument.defaultView?.innerHeight
+      ?? 0;
+    const maxHeight = calculateTextareaMaxHeight(viewHeight);
+
+    const scroller = this.view.dom.querySelector<HTMLElement>('.cm-scroller');
+    const contentHeight = scroller
+      ? Math.min(scroller.scrollHeight, maxHeight)
+      : TEXTAREA_BASE_MIN_HEIGHT;
+    const minHeight = calculateTextareaMinHeight({
+      contentHeight,
+      flexAllocatedHeight: this.view.dom.offsetHeight,
+    });
+
+    this.view.dom.setCssProps({
+      '--qoderian-textarea-min-height': `${minHeight}px`,
+      '--qoderian-textarea-max-height': `${maxHeight}px`,
+    });
+  }
+}

--- a/src/features/chat/ui/composer/live-composer.ts
+++ b/src/features/chat/ui/composer/live-composer.ts
@@ -61,10 +61,11 @@ class ReferenceWidget extends WidgetType {
   }
 
   toDOM(view: EditorView): HTMLElement {
-    const { reference } = this.range;
+    const { reference, from, to } = this.range;
     const element = createDetachedElement(view, 'span');
     const icon = createDetachedElement(view, 'span');
     const label = createDetachedElement(view, 'span');
+    const remove = createDetachedElement(view, 'span');
 
     element.classList.add('qoderian-composer-reference');
     element.classList.toggle('qoderian-composer-reference--selected', this.selected);
@@ -75,11 +76,21 @@ class ReferenceWidget extends WidgetType {
     setIcon(icon, reference.kind === 'folder' ? 'folder' : 'file-text');
     label.classList.add('qoderian-composer-reference-label');
     label.textContent = formatReferenceLabel(reference.path);
-    element.append(icon, label);
+    remove.classList.add('qoderian-composer-reference-remove');
+    remove.setAttribute('aria-label', `Remove ${reference.token}`);
+    setIcon(remove, 'x');
+    element.append(icon, label, remove);
     // Plain click opens the reference, same as message-bubble chips.
     element.addEventListener('click', (event) => {
       event.preventDefault();
       this.onOpenReference?.(reference);
+    });
+    // The remove button deletes the whole token, like an atomic Backspace.
+    remove.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      view.dispatch({ changes: { from, to } });
+      view.focus();
     });
     return element;
   }

--- a/src/features/chat/ui/file-context/file-context-manager.ts
+++ b/src/features/chat/ui/file-context/file-context-manager.ts
@@ -361,8 +361,8 @@ export class FileContextManager {
   // Composer References
   // ========================================
 
-  /** Registers a reference inserted via the mention dropdown and updates chips. */
-  private registerComposerReference(reference: MentionInsertReference): void {
+  /** Registers a reference inserted via the mention dropdown or a vault drop. */
+  registerComposerReference(reference: MentionInsertReference): void {
     this.composerReferences.set(reference.token, reference);
     this.notifyReferencesChanged();
   }

--- a/src/features/chat/ui/file-context/file-context-manager.ts
+++ b/src/features/chat/ui/file-context/file-context-manager.ts
@@ -17,7 +17,9 @@ import type { McpServerManager } from '../../../../qoder/mcp/mcp-server-manager'
 import { appendMcpIcon } from '../../../../shared/icons';
 import { MentionDropdownController } from '../../../../shared/mention/mention-dropdown-controller';
 import type { ExtensionMentionItem, MentionExtensionProvider } from '../../../../shared/mention/types';
+import type { MentionInsertReference } from '../../../../shared/mention/types';
 import { VaultMentionIndex } from '../../../../shared/mention/vault-mention-index';
+import type { ComposerReference } from '../composer/composer-reference';
 import { FileChipsView } from './file-chips-view';
 import { FileContextState } from './file-context-state';
 import { isTagExcluded } from './tag-exclusion';
@@ -25,6 +27,8 @@ import { isTagExcluded } from './tag-exclusion';
 export interface FileContextCallbacks {
   getExcludedTags: () => string[];
   onChipsChanged?: () => void;
+  /** Notified whenever the composer reference set changes (insert/rename/delete). */
+  onReferencesChanged?: (references: readonly ComposerReference[]) => void;
   getExternalContexts?: () => string[];
   /** Called when an agent is selected from the @ mention dropdown. */
   onAgentMentionSelect?: (agentId: string) => void;
@@ -47,6 +51,9 @@ export class FileContextManager {
 
   // Current note (shown as chip)
   private currentNotePath: string | null = null;
+
+  // Reference tokens inserted via the mention dropdown, keyed by token text
+  private readonly composerReferences = new Map<string, ComposerReference>();
 
   // MCP server support
   private onMcpMentionChange: ((servers: Set<string>) => void) | null = null;
@@ -97,6 +104,7 @@ export class FileContextManager {
       this.inputEl,
       {
         onAttachFile: (filePath) => this.state.attachFile(filePath),
+        onInsertReference: (reference) => this.registerComposerReference(reference),
         getExternalContexts: () => this.callbacks.getExternalContexts?.() || [],
         getCachedVaultFolders: () => this.mentionIndex.getCachedVaultFolders(),
         getCachedVaultFiles: () => this.mentionIndex.getCachedVaultFiles(),
@@ -311,6 +319,11 @@ export class FileContextManager {
       needsUpdate = true;
     }
 
+    // Update composer reference tokens so chips survive renames
+    if (this.renameComposerReferences(normalizedOld, normalizedNew)) {
+      needsUpdate = true;
+    }
+
     if (needsUpdate) {
       this.refreshCurrentNoteChip();
     }
@@ -334,9 +347,65 @@ export class FileContextManager {
       needsUpdate = true;
     }
 
+    // Drop composer references whose file no longer exists
+    if (this.removeComposerReferencesForPath(normalized)) {
+      needsUpdate = true;
+    }
+
     if (needsUpdate) {
       this.refreshCurrentNoteChip();
     }
+  }
+
+  // ========================================
+  // Composer References
+  // ========================================
+
+  /** Registers a reference inserted via the mention dropdown and updates chips. */
+  private registerComposerReference(reference: MentionInsertReference): void {
+    this.composerReferences.set(reference.token, reference);
+    this.notifyReferencesChanged();
+  }
+
+  /**
+   * Rewrites references under a renamed path: tokens in the input text are
+   * replaced so chips keep pointing at the new location.
+   */
+  private renameComposerReferences(oldPath: string, newPath: string | null): boolean {
+    let changed = false;
+    for (const [token, reference] of Array.from(this.composerReferences.entries())) {
+      if (reference.path !== oldPath) continue;
+
+      this.composerReferences.delete(token);
+      if (newPath) {
+        const newToken = token.replace(oldPath, newPath);
+        const renamed = { ...reference, token: newToken, path: newPath };
+        this.composerReferences.set(newToken, renamed);
+        this.inputEl.value = this.inputEl.value.split(token).join(newToken);
+      } else {
+        this.inputEl.value = this.inputEl.value.split(token).join('');
+      }
+      changed = true;
+    }
+    if (changed) this.notifyReferencesChanged();
+    return changed;
+  }
+
+  /** Removes references pointing at a deleted path, dropping their tokens. */
+  private removeComposerReferencesForPath(deletedPath: string): boolean {
+    let changed = false;
+    for (const [token, reference] of Array.from(this.composerReferences.entries())) {
+      if (reference.path !== deletedPath) continue;
+      this.composerReferences.delete(token);
+      this.inputEl.value = this.inputEl.value.split(token).join('');
+      changed = true;
+    }
+    if (changed) this.notifyReferencesChanged();
+    return changed;
+  }
+
+  private notifyReferencesChanged(): void {
+    this.callbacks.onReferencesChanged?.(Array.from(this.composerReferences.values()));
   }
 
   // ========================================

--- a/src/features/chat/ui/vault-drop.ts
+++ b/src/features/chat/ui/vault-drop.ts
@@ -2,11 +2,17 @@ import type { App } from 'obsidian';
 import { TFile, TFolder } from 'obsidian';
 
 import { t } from '@/i18n/i18n';
+import type { MentionInsertReference } from '@/shared/mention/types';
 
 /** A vault file or folder reference extracted from an Obsidian drag payload. */
 export interface VaultDropReference {
   path: string;
   kind: 'file' | 'folder';
+}
+
+export interface VaultDropOptions {
+  /** Called for every inserted reference so consumers can chipify it. */
+  onInsertReference?: (reference: MentionInsertReference) => void;
 }
 
 interface DragManagerHost {
@@ -18,28 +24,33 @@ interface DragManagerHost {
  * `@path` / `@path/ ` mention tokens at the caret position.
  *
  * Must be attached before ImageContextManager so vault drags can be claimed
- * via stopImmediatePropagation before the image drop handlers run.
+ * via stopImmediatePropagation before the image drop handlers run. The drop
+ * listener runs in the capture phase so inner editors (CodeMirror) never see
+ * vault drops and cannot paste the OS-level `obsidian://` URI payload.
  */
 export class VaultDropController {
   private readonly dropOverlayEl: HTMLElement;
+  private readonly onInsertReference?: (reference: MentionInsertReference) => void;
 
   constructor(
     private readonly app: App,
     private readonly inputWrapperEl: HTMLElement,
     private readonly inputEl: HTMLTextAreaElement,
+    options: VaultDropOptions = {},
   ) {
+    this.onInsertReference = options.onInsertReference;
     this.dropOverlayEl = this.createDropOverlay();
     this.inputWrapperEl.addEventListener('dragenter', this.handleDragEnter);
     this.inputWrapperEl.addEventListener('dragover', this.handleDragOver);
     this.inputWrapperEl.addEventListener('dragleave', this.handleDragLeave);
-    this.inputWrapperEl.addEventListener('drop', this.handleDrop);
+    this.inputWrapperEl.addEventListener('drop', this.handleDrop, true);
   }
 
   destroy(): void {
     this.inputWrapperEl.removeEventListener('dragenter', this.handleDragEnter);
     this.inputWrapperEl.removeEventListener('dragover', this.handleDragOver);
     this.inputWrapperEl.removeEventListener('dragleave', this.handleDragLeave);
-    this.inputWrapperEl.removeEventListener('drop', this.handleDrop);
+    this.inputWrapperEl.removeEventListener('drop', this.handleDrop, true);
     this.dropOverlayEl.remove();
   }
 
@@ -81,6 +92,13 @@ export class VaultDropController {
     const newReferences = references.filter((reference) => !this.inputContainsReference(reference));
     if (newReferences.length > 0) {
       this.insertReferences(newReferences);
+      for (const reference of newReferences) {
+        this.onInsertReference?.({
+          token: this.mentionToken(reference),
+          path: reference.path,
+          kind: reference.kind,
+        });
+      }
       this.inputEl.dispatchEvent(new Event('input', { bubbles: true }));
     }
     this.inputEl.focus();

--- a/src/shared/markdown/mention-chip.ts
+++ b/src/shared/markdown/mention-chip.ts
@@ -1,0 +1,162 @@
+/**
+ * Qoderian - Mention Chip Utilities
+ *
+ * Replaces `@path` reference tokens in user message markdown with inline
+ * chip HTML before MarkdownRenderer processes the content. Mirrors the
+ * composer reference chips so sent bubbles match what the user typed.
+ *
+ * Note: This is display-only - the agent still receives the raw `@path` text.
+ */
+
+import type { App, TAbstractFile } from 'obsidian';
+import { TFile, TFolder } from 'obsidian';
+
+import { escapeHtml } from './html';
+
+/** Trailing punctuation stripped from a candidate token before vault lookup. */
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}"'”»›）》」』】…]+$/;
+
+/** Code fences and inline code are skipped so snippets keep their raw text. */
+const CODE_SEGMENTS = /(```[\s\S]*?(?:```|$)|`[^`\n]+`)/g;
+
+export interface MentionCandidate {
+  /** Token text including the leading `@` (before punctuation stripping). */
+  raw: string;
+  /** Path to look up in the vault (no `@`, no trailing slash/punctuation). */
+  path: string;
+  /** True when the raw token ended with a folder slash. */
+  hasTrailingSlash: boolean;
+  start: number;
+  end: number;
+}
+
+/**
+ * Formats a chip label from a path: the basename, truncated with an ellipsis.
+ * Shared with the live composer so both surfaces show identical labels.
+ */
+export function formatReferenceLabel(path: string): string {
+  const segments = path.replace(/\\/g, '/').split('/');
+  const basename = segments[segments.length - 1] || path;
+  const characters = Array.from(basename);
+  return characters.length > 20
+    ? `${characters.slice(0, 20).join('')}…`
+    : basename;
+}
+
+function isTokenBoundary(char: string | undefined): boolean {
+  return char === undefined || /\s/.test(char);
+}
+
+/** Finds `@path` candidates outside code spans; verification is left to the caller. */
+export function findMentionCandidates(text: string): MentionCandidate[] {
+  const candidates: MentionCandidate[] = [];
+  const segments = text.split(CODE_SEGMENTS);
+  let offset = 0;
+  let isCodeSegment = false;
+
+  for (const segment of segments) {
+    if (!isCodeSegment) {
+      collectSegmentCandidates(segment, offset, candidates);
+    }
+    offset += segment.length;
+    isCodeSegment = !isCodeSegment;
+  }
+
+  return candidates;
+}
+
+function collectSegmentCandidates(
+  segment: string,
+  segmentOffset: number,
+  candidates: MentionCandidate[],
+): void {
+  for (let index = 0; index < segment.length; index++) {
+    if (segment[index] !== '@') continue;
+    if (!isTokenBoundary(segment[index - 1])) continue;
+
+    let end = index + 1;
+    while (end < segment.length && !/\s/.test(segment[end])) {
+      end++;
+    }
+    const raw = segment.slice(index, end);
+    if (raw.length <= 1) continue;
+
+    const stripped = raw.slice(1).replace(TRAILING_PUNCTUATION, '');
+    if (stripped.length === 0) continue;
+
+    const hasTrailingSlash = stripped.endsWith('/');
+    const path = hasTrailingSlash ? stripped.slice(0, -1) : stripped;
+    if (!path) continue;
+
+    candidates.push({
+      raw: stripped,
+      path,
+      hasTrailingSlash,
+      start: segmentOffset + index,
+      // +1 covers the leading `@` that `stripped` no longer includes.
+      end: segmentOffset + index + stripped.length + 1,
+    });
+
+    index = end - 1;
+  }
+}
+
+function createChipHtml(path: string, kind: 'file' | 'folder'): string {
+  const label = escapeHtml(formatReferenceLabel(path));
+  const escapedPath = escapeHtml(path);
+  const title = escapeHtml(`@${path}${kind === 'folder' ? '/' : ''}`);
+  return (
+    `<span class="qoderian-composer-reference qoderian-msg-reference"`
+    + ` data-kind="${kind}" data-path="${escapedPath}" title="${title}">`
+    + `<span class="qoderian-composer-reference-icon"></span>`
+    + `<span class="qoderian-composer-reference-label">${label}</span>`
+    + `</span>`
+  );
+}
+
+/**
+ * Call before MarkdownRenderer.render(). Every `@path` token that resolves to
+ * an existing vault file or folder becomes a chip; unknown tokens and code
+ * spans pass through unchanged.
+ */
+export function replaceMentionTokensWithHtml(markdown: string, app: App): string {
+  if (!app?.vault || !markdown.includes('@')) {
+    return markdown;
+  }
+
+  const candidates = findMentionCandidates(markdown);
+  if (candidates.length === 0) {
+    return markdown;
+  }
+
+  const chunks: string[] = [];
+  let cursor = 0;
+  for (const candidate of candidates) {
+    if (candidate.start < cursor) continue;
+
+    let resolved: TAbstractFile | null = null;
+    try {
+      resolved = app.vault.getAbstractFileByPath(candidate.path);
+    } catch {
+      // Vault lookup failures leave the token untouched.
+    }
+    const kind = resolved instanceof TFolder
+      ? 'folder'
+      : resolved instanceof TFile
+        ? 'file'
+        : null;
+    if (!kind || !resolved) {
+      continue;
+    }
+
+    chunks.push(markdown.slice(cursor, candidate.start));
+    chunks.push(createChipHtml(candidate.path, kind));
+    cursor = candidate.end;
+  }
+  if (chunks.length === 0) {
+    return markdown;
+  }
+
+  chunks.push(markdown.slice(cursor));
+  return chunks.join('');
+}

--- a/src/shared/markdown/mention-chip.ts
+++ b/src/shared/markdown/mention-chip.ts
@@ -48,8 +48,17 @@ function isTokenBoundary(char: string | undefined): boolean {
   return char === undefined || /\s/.test(char);
 }
 
-/** Finds `@path` candidates outside code spans; verification is left to the caller. */
-export function findMentionCandidates(text: string): MentionCandidate[] {
+/**
+ * Finds `@path` candidates outside code spans.
+ *
+ * Without a resolver, tokens end at the first whitespace. With one, the
+ * longest span (up to a newline) is tried first and shrunk word-by-word from
+ * the right until the path resolves, so paths containing spaces chipify.
+ */
+export function findMentionCandidates(
+  text: string,
+  resolvePath?: (path: string) => boolean,
+): MentionCandidate[] {
   const candidates: MentionCandidate[] = [];
   const segments = text.split(CODE_SEGMENTS);
   let offset = 0;
@@ -57,7 +66,7 @@ export function findMentionCandidates(text: string): MentionCandidate[] {
 
   for (const segment of segments) {
     if (!isCodeSegment) {
-      collectSegmentCandidates(segment, offset, candidates);
+      collectSegmentCandidates(segment, offset, candidates, resolvePath);
     }
     offset += segment.length;
     isCodeSegment = !isCodeSegment;
@@ -70,19 +79,27 @@ function collectSegmentCandidates(
   segment: string,
   segmentOffset: number,
   candidates: MentionCandidate[],
+  resolvePath?: (path: string) => boolean,
 ): void {
   for (let index = 0; index < segment.length; index++) {
     if (segment[index] !== '@') continue;
     if (!isTokenBoundary(segment[index - 1])) continue;
 
-    let end = index + 1;
-    while (end < segment.length && !/\s/.test(segment[end])) {
-      end++;
+    let firstSpaceEnd = index + 1;
+    while (firstSpaceEnd < segment.length && !/\s/.test(segment[firstSpaceEnd])) {
+      firstSpaceEnd++;
     }
-    const raw = segment.slice(index, end);
+
+    const resolved = resolvePath
+      ? resolveLongestPath(segment, index, resolvePath)
+      : null;
+
+    const raw = segment.slice(index, resolved ? resolved.end : firstSpaceEnd);
     if (raw.length <= 1) continue;
 
-    const stripped = raw.slice(1).replace(TRAILING_PUNCTUATION, '');
+    const stripped = resolved
+      ? resolved.stripped
+      : raw.slice(1).replace(TRAILING_PUNCTUATION, '');
     if (stripped.length === 0) continue;
 
     const hasTrailingSlash = stripped.endsWith('/');
@@ -98,8 +115,48 @@ function collectSegmentCandidates(
       end: segmentOffset + index + stripped.length + 1,
     });
 
-    index = end - 1;
+    index = (resolved ? resolved.end : firstSpaceEnd) - 1;
   }
+}
+
+/**
+ * Tries the longest `@` span (up to a newline, trailing whitespace trimmed)
+ * and shrinks it word-by-word from the right until `resolvePath` accepts the
+ * path. Longest-first keeps a following sentence from being swallowed when a
+ * shorter path also exists.
+ */
+function resolveLongestPath(
+  segment: string,
+  atIndex: number,
+  resolvePath: (path: string) => boolean,
+): { stripped: string; end: number } | null {
+  let maxEnd = atIndex + 1;
+  while (maxEnd < segment.length && segment[maxEnd] !== '\n') maxEnd++;
+  while (maxEnd > atIndex + 1 && /\s/.test(segment[maxEnd - 1])) maxEnd--;
+
+  let spanEnd = maxEnd;
+  while (spanEnd > atIndex + 1) {
+    const stripped = segment.slice(atIndex + 1, spanEnd).replace(TRAILING_PUNCTUATION, '');
+    if (stripped.length > 0) {
+      const path = stripped.endsWith('/') ? stripped.slice(0, -1) : stripped;
+      if (path.length > 0 && resolvePath(path)) {
+        return { stripped, end: atIndex + 1 + stripped.length + 1 };
+      }
+    }
+
+    const span = segment.slice(atIndex + 1, spanEnd);
+    let lastSpace = -1;
+    for (let i = span.length - 1; i >= 0; i--) {
+      if (/\s/.test(span[i])) {
+        lastSpace = i;
+        break;
+      }
+    }
+    if (lastSpace === -1) return null;
+    spanEnd = atIndex + 1 + lastSpace;
+    while (spanEnd > atIndex + 1 && /\s/.test(segment[spanEnd - 1])) spanEnd--;
+  }
+  return null;
 }
 
 function createChipHtml(path: string, kind: ReferenceChipKind): string {
@@ -125,7 +182,14 @@ export function replaceMentionTokensWithHtml(markdown: string, app: App): string
     return markdown;
   }
 
-  const candidates = findMentionCandidates(markdown);
+  const resolvePath = (path: string): boolean => {
+    try {
+      return app.vault.getAbstractFileByPath(path) !== null;
+    } catch {
+      return false;
+    }
+  };
+  const candidates = findMentionCandidates(markdown, resolvePath);
   if (candidates.length === 0) {
     return markdown;
   }

--- a/src/shared/markdown/mention-chip.ts
+++ b/src/shared/markdown/mention-chip.ts
@@ -11,6 +11,7 @@
 import type { App, TAbstractFile } from 'obsidian';
 import { TFile, TFolder } from 'obsidian';
 
+import type { ReferenceChipKind } from '../mention/types';
 import { escapeHtml } from './html';
 
 /** Trailing punctuation stripped from a candidate token before vault lookup. */
@@ -101,7 +102,7 @@ function collectSegmentCandidates(
   }
 }
 
-function createChipHtml(path: string, kind: 'file' | 'folder'): string {
+function createChipHtml(path: string, kind: ReferenceChipKind): string {
   const label = escapeHtml(formatReferenceLabel(path));
   const escapedPath = escapeHtml(path);
   const title = escapeHtml(`@${path}${kind === 'folder' ? '/' : ''}`);
@@ -140,7 +141,7 @@ export function replaceMentionTokensWithHtml(markdown: string, app: App): string
     } catch {
       // Vault lookup failures leave the token untouched.
     }
-    const kind = resolved instanceof TFolder
+    const kind: ReferenceChipKind | null = resolved instanceof TFolder
       ? 'folder'
       : resolved instanceof TFile
         ? 'file'

--- a/src/shared/mention/mention-dropdown-controller.ts
+++ b/src/shared/mention/mention-dropdown-controller.ts
@@ -7,6 +7,7 @@ import { SelectableDropdown } from '../components/selectable-dropdown';
 import {
   type FolderMentionItem,
   type MentionExtensionProvider,
+  type MentionInsertReference,
   type MentionItem,
 } from './types';
 
@@ -16,6 +17,8 @@ export interface MentionDropdownOptions {
 
 export interface MentionDropdownCallbacks {
   onAttachFile: (path: string) => void;
+  /** Notified with the exact token inserted for file/folder/context-file mentions. */
+  onInsertReference?: (reference: MentionInsertReference) => void;
   getExternalContexts: () => string[];
   getCachedVaultFolders: () => Array<Pick<FolderMentionItem, 'name' | 'path'>>;
   getCachedVaultFiles: () => TFile[];
@@ -536,12 +539,23 @@ export class MentionDropdownController {
         if (selectedItem.absolutePath) {
           this.callbacks.onAttachFile(selectedItem.absolutePath);
         }
+        this.callbacks.onInsertReference?.({
+          token: displayName,
+          path: selectedItem.absolutePath || selectedItem.name,
+          kind: 'file',
+        });
         this.insertReplacement(beforeAt, `${displayName} `, afterCursor);
         break;
       }
       case 'folder': {
         const normalizedPath = this.callbacks.normalizePathForVault(selectedItem.path);
-        this.insertReplacement(beforeAt, `@${normalizedPath ?? selectedItem.path}/ `, afterCursor);
+        const folderPath = normalizedPath ?? selectedItem.path;
+        this.callbacks.onInsertReference?.({
+          token: `@${folderPath}/`,
+          path: folderPath,
+          kind: 'folder',
+        });
+        this.insertReplacement(beforeAt, `@${folderPath}/ `, afterCursor);
         break;
       }
       default: {
@@ -549,6 +563,11 @@ export class MentionDropdownController {
         const normalizedPath = this.callbacks.normalizePathForVault(rawPath);
         if (normalizedPath) {
           this.callbacks.onAttachFile(normalizedPath);
+          this.callbacks.onInsertReference?.({
+            token: `@${normalizedPath}`,
+            path: normalizedPath,
+            kind: 'file',
+          });
         }
         this.insertReplacement(beforeAt, `@${normalizedPath ?? selectedItem.name} `, afterCursor);
         break;

--- a/src/shared/mention/types.ts
+++ b/src/shared/mention/types.ts
@@ -57,3 +57,19 @@ export type MentionItem =
   | ContextFileMentionItem
   | ContextFolderMentionItem
   | ExtensionMentionItem;
+
+/**
+ * Kinds a reference chip can represent. Drives the chip icon and the click
+ * behavior dispatched by `openReferenceChip`; extend this union (and the
+ * action registry) to support new reference targets.
+ */
+export type ReferenceChipKind = 'file' | 'folder';
+
+/** A reference token inserted into the input by selecting a mention item. */
+export interface MentionInsertReference {
+  /** Token text inserted into the input, including the leading `@`. */
+  token: string;
+  /** Path used for chip labels and open actions. */
+  path: string;
+  kind: ReferenceChipKind;
+}

--- a/src/shared/obsidian/compat.ts
+++ b/src/shared/obsidian/compat.ts
@@ -1,4 +1,5 @@
-import type { App, TFile, Workspace, WorkspaceLeaf } from 'obsidian';
+import type { App, TAbstractFile, TFile, TFolder, Workspace, WorkspaceLeaf } from 'obsidian';
+import { Notice } from 'obsidian';
 
 export function getVaultFileByPath(app: App, filePath: string): TFile | null {
   const file = app.vault.getAbstractFileByPath(filePath);
@@ -12,6 +13,55 @@ export async function revealWorkspaceLeaf(workspace: Workspace, leaf: WorkspaceL
   await workspace.revealLeaf(leaf);
 }
 
+/**
+ * Opens a vault file or folder the way users expect from a reference chip:
+ * files open in a leaf, folders are revealed in the file explorer.
+ * `openLinkText` cannot be used here — it treats folder paths as missing
+ * notes and offers to create a file.
+ */
+export function openVaultEntry(app: App, path: string): void {
+  const entry = app.vault.getAbstractFileByPath(path);
+  if (!entry) return;
+
+  if (isVaultFolder(entry)) {
+    revealInFileExplorer(app, entry);
+    return;
+  }
+  if (isVaultFile(entry)) {
+    void (async (): Promise<void> => {
+      try {
+        await app.workspace.getLeaf().openFile(entry);
+      } catch (error) {
+        new Notice(`Failed to open file: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    })();
+  }
+}
+
+/** Internal file-explorer API used by community plugins to locate an entry. */
+interface FileExplorerPluginApi {
+  instance?: {
+    revealInFolder?: (entry: TAbstractFile) => void;
+  };
+}
+
+function revealInFileExplorer(app: App, folder: TFolder): void {
+  try {
+    const internalPlugins = (app as unknown as {
+      internalPlugins?: { getPluginById?: (id: string) => FileExplorerPluginApi | undefined };
+    }).internalPlugins;
+    const explorer = internalPlugins?.getPluginById?.('file-explorer');
+    const reveal = explorer?.instance?.revealInFolder;
+    if (typeof reveal === 'function') {
+      reveal.call(explorer?.instance, folder);
+      return;
+    }
+  } catch {
+    // File explorer unavailable or API changed; fall through to the notice.
+  }
+  new Notice(`Cannot reveal folder: ${folder.path}`);
+}
+
 function isVaultFile(value: unknown): value is TFile {
   if (!value || typeof value !== 'object') {
     return false;
@@ -20,4 +70,15 @@ function isVaultFile(value: unknown): value is TFile {
   const candidate = value as Partial<TFile>;
   return typeof candidate.path === 'string'
     && typeof candidate.basename === 'string';
+}
+
+function isVaultFolder(value: unknown): value is TFolder {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<TFolder>;
+  return typeof candidate.path === 'string'
+    && typeof candidate.name === 'string'
+    && Array.isArray(candidate.children);
 }

--- a/src/shared/obsidian/compat.ts
+++ b/src/shared/obsidian/compat.ts
@@ -1,6 +1,8 @@
 import type { App, TAbstractFile, TFile, TFolder, Workspace, WorkspaceLeaf } from 'obsidian';
 import { Notice } from 'obsidian';
 
+import type { ReferenceChipKind } from '../mention/types';
+
 export function getVaultFileByPath(app: App, filePath: string): TFile | null {
   const file = app.vault.getAbstractFileByPath(filePath);
   if (isVaultFile(file)) {
@@ -13,35 +15,66 @@ export async function revealWorkspaceLeaf(workspace: Workspace, leaf: WorkspaceL
   await workspace.revealLeaf(leaf);
 }
 
+export type ReferenceChipAction = (app: App, path: string) => void;
+
 /**
- * Opens a vault file or folder the way users expect from a reference chip:
- * files open in a leaf, folders are revealed in the file explorer.
- * `openLinkText` cannot be used here — it treats folder paths as missing
+ * Click behaviors per chip kind. Extend `ReferenceChipKind` and add an entry
+ * here to support new reference targets (e.g. files outside the vault).
+ */
+const referenceChipActions: Record<ReferenceChipKind, ReferenceChipAction> = {
+  file: openReferenceFile,
+  folder: revealReferenceFolder,
+};
+
+/**
+ * Dispatches a reference chip click by its declared kind. Actions re-resolve
+ * the path against the vault, so a stale kind (renamed or replaced entry)
+ * falls through to the actual entry's behavior instead of misfiring.
+ * `openLinkText` must not be used here — it treats folder paths as missing
  * notes and offers to create a file.
  */
-export function openVaultEntry(app: App, path: string): void {
+export function openReferenceChip(app: App, kind: ReferenceChipKind, path: string): void {
+  referenceChipActions[kind]?.(app, path);
+}
+
+function openReferenceFile(app: App, path: string): void {
   const entry = app.vault.getAbstractFileByPath(path);
   if (!entry) return;
 
   if (isVaultFolder(entry)) {
-    revealInFileExplorer(app, entry);
+    referenceChipActions.folder(app, path);
     return;
   }
+  if (!isVaultFile(entry)) return;
+
+  void (async (): Promise<void> => {
+    try {
+      await app.workspace.getLeaf().openFile(entry);
+    } catch (error) {
+      new Notice(`Failed to open file: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  })();
+}
+
+function revealReferenceFolder(app: App, path: string): void {
+  const entry = app.vault.getAbstractFileByPath(path);
+  if (!entry) return;
+
   if (isVaultFile(entry)) {
-    void (async (): Promise<void> => {
-      try {
-        await app.workspace.getLeaf().openFile(entry);
-      } catch (error) {
-        new Notice(`Failed to open file: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    })();
+    referenceChipActions.file(app, path);
+    return;
   }
+  if (!isVaultFolder(entry)) return;
+
+  revealInFileExplorer(app, entry);
 }
 
 /** Internal file-explorer API used by community plugins to locate an entry. */
 interface FileExplorerPluginApi {
   instance?: {
     revealInFolder?: (entry: TAbstractFile) => void;
+    /** FileExplorerView extends View, which exposes its container element. */
+    containerEl?: HTMLElement;
   };
 }
 
@@ -50,16 +83,37 @@ function revealInFileExplorer(app: App, folder: TFolder): void {
     const internalPlugins = (app as unknown as {
       internalPlugins?: { getPluginById?: (id: string) => FileExplorerPluginApi | undefined };
     }).internalPlugins;
-    const explorer = internalPlugins?.getPluginById?.('file-explorer');
-    const reveal = explorer?.instance?.revealInFolder;
+    const instance = internalPlugins?.getPluginById?.('file-explorer')?.instance;
+    const reveal = instance?.revealInFolder;
     if (typeof reveal === 'function') {
-      reveal.call(explorer?.instance, folder);
+      reveal.call(instance, folder);
+      flashRevealedEntry(instance?.containerEl, folder.path);
       return;
     }
   } catch {
     // File explorer unavailable or API changed; fall through to the notice.
   }
   new Notice(`Cannot reveal folder: ${folder.path}`);
+}
+
+/**
+ * Adds a short flash to the revealed tree entry so the chip click has a
+ * visible landing point. Scoped to our own class, so the explorer's normal
+ * active styling (and the user's theme) stays untouched.
+ */
+function flashRevealedEntry(containerEl: HTMLElement | undefined, path: string): void {
+  if (!containerEl) return;
+
+  const escapedPath = typeof CSS !== 'undefined' && CSS.escape
+    ? CSS.escape(path)
+    : path.replace(/"/g, '\\"');
+  const item = containerEl.querySelector(`.tree-item-self[data-path="${escapedPath}"]`);
+  if (!item) return;
+
+  item.classList.add('qoderian-reveal-flash');
+  window.setTimeout(() => {
+    item.classList.remove('qoderian-reveal-flash');
+  }, 1800);
 }
 
 function isVaultFile(value: unknown): value is TFile {

--- a/src/style/components/composer.css
+++ b/src/style/components/composer.css
@@ -1,0 +1,111 @@
+/* Live composer (CodeMirror-backed input with inline reference chips) */
+
+/* The legacy textarea stays in the DOM as the wiring target; the bridge
+   hides it and renders the CodeMirror surface in its place. */
+.qoderian-input-wrapper textarea.qoderian-input.qoderian-composer-source {
+  display: none;
+}
+
+.qoderian-input-wrapper .qoderian-live-composer-host {
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+  min-width: 0;
+}
+
+/* Editor surface mirrors the old textarea box model (padding, font metrics,
+   height bounds) so the wrapper layout stays identical. */
+.qoderian-input-wrapper .qoderian-live-composer.cm-editor {
+  flex: 1 1 auto;
+  min-height: var(--qoderian-textarea-min-height, 60px);
+  max-height: var(--qoderian-textarea-max-height, none);
+  background: transparent;
+  color: var(--text-normal);
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.qoderian-input-wrapper .qoderian-live-composer.cm-focused {
+  outline: none;
+}
+
+.qoderian-input-wrapper .qoderian-live-composer .cm-scroller {
+  font-family: inherit;
+  line-height: 1.4;
+  overflow-y: auto;
+}
+
+.qoderian-input-wrapper .qoderian-live-composer .cm-content {
+  padding: 8px 10px 10px 10px;
+  caret-color: var(--text-normal);
+}
+
+.qoderian-input-wrapper .qoderian-live-composer .cm-placeholder {
+  color: var(--text-faint);
+  opacity: 0.8;
+}
+
+/* Monospace input while in bash mode (mirrors the textarea rule) */
+.qoderian-input-wrapper.qoderian-input-bang-bash-mode .qoderian-live-composer .cm-scroller {
+  font-family: var(--font-monospace);
+}
+
+/* Inline reference chip replacing an `@path` token in the text flow */
+.qoderian-composer-reference {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0 1px;
+  padding: 2px 6px;
+  background: var(--background-modifier-hover);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  max-width: 220px;
+  vertical-align: baseline;
+  cursor: pointer;
+}
+
+.qoderian-composer-reference:hover {
+  background: var(--background-modifier-active-hover);
+}
+
+.qoderian-composer-reference--selected {
+  border-color: var(--interactive-accent);
+  background: var(--background-modifier-active-hover);
+}
+
+.qoderian-composer-reference-icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.qoderian-composer-reference-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+.qoderian-composer-reference-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-normal);
+}
+
+/* Chips inside user message bubbles sit on the dark bubble background;
+   translucent white reads as a highlight pill there. */
+.qoderian-message-user .qoderian-composer-reference {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.qoderian-message-user .qoderian-composer-reference:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.qoderian-message-user .qoderian-composer-reference-label {
+  color: var(--text-normal);
+}

--- a/src/style/components/composer.css
+++ b/src/style/components/composer.css
@@ -109,3 +109,22 @@
 .qoderian-message-user .qoderian-composer-reference-label {
   color: var(--text-normal);
 }
+
+/* Flash highlight on a folder revealed from a reference chip click. Owns no
+   permanent styling — the animation fades out and the class is removed. */
+@keyframes qoderian-reveal-flash {
+  0%, 35% {
+    background: color-mix(in srgb, var(--qoderian-brand) 32%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--qoderian-brand) 55%, transparent);
+  }
+
+  100% {
+    background: transparent;
+    box-shadow: none;
+  }
+}
+
+.tree-item-self.qoderian-reveal-flash {
+  animation: qoderian-reveal-flash 1.8s ease-out;
+  border-radius: var(--radius-s);
+}

--- a/src/style/components/composer.css
+++ b/src/style/components/composer.css
@@ -95,6 +95,25 @@
   color: var(--text-normal);
 }
 
+/* Composer-only remove button; bubble chips are built without it. */
+.qoderian-composer-reference-remove {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.qoderian-composer-reference-remove:hover {
+  color: var(--text-normal);
+}
+
+.qoderian-composer-reference-remove svg {
+  width: 11px;
+  height: 11px;
+}
+
 /* Chips inside user message bubbles sit on the dark bubble background;
    translucent white reads as a highlight pill there. */
 .qoderian-message-user .qoderian-composer-reference {

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -18,6 +18,7 @@
 @import "./components/status-panel.css";
 @import "./components/subagent.css";
 @import "./components/input.css";
+@import "./components/composer.css";
 @import "./components/context-footer.css";
 
 /* Toolbar */

--- a/tests/unit/features/chat/ui/composer-reference.test.ts
+++ b/tests/unit/features/chat/ui/composer-reference.test.ts
@@ -1,0 +1,105 @@
+import {
+  type ComposerReference,
+  findAtomicDeleteRange,
+  findReferenceRanges,
+  formatReferenceLabel,
+} from '../../../../../src/features/chat/ui/composer/composer-reference';
+
+const fileRef: ComposerReference = { token: '@notes/idea.md', path: 'notes/idea.md', kind: 'file' };
+const folderRef: ComposerReference = { token: '@projects/', path: 'projects', kind: 'folder' };
+
+describe('formatReferenceLabel', () => {
+  it('uses the basename as the label', () => {
+    expect(formatReferenceLabel('folder/note.md')).toBe('note.md');
+  });
+
+  it('falls back to the whole path when there is no separator', () => {
+    expect(formatReferenceLabel('note.md')).toBe('note.md');
+  });
+
+  it('truncates long basenames with an ellipsis', () => {
+    const longName = 'a'.repeat(30);
+    expect(formatReferenceLabel(`folder/${longName}`)).toBe(`${'a'.repeat(20)}…`);
+  });
+
+  it('handles backslash paths', () => {
+    expect(formatReferenceLabel('folder\\note.md')).toBe('note.md');
+  });
+});
+
+describe('findReferenceRanges', () => {
+  it('finds a token surrounded by whitespace', () => {
+    const ranges = findReferenceRanges(`look at ${fileRef.token} please`, [fileRef]);
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0]).toMatchObject({ from: 8, to: 8 + fileRef.token.length });
+  });
+
+  it('matches a token at the start and end of the text', () => {
+    const ranges = findReferenceRanges(`${fileRef.token} middle ${folderRef.token}`, [
+      fileRef,
+      folderRef,
+    ]);
+    expect(ranges.map(range => range.reference.kind)).toEqual(['file', 'folder']);
+    expect(ranges[0].from).toBe(0);
+    expect(ranges[1].to).toBe(fileRef.token.length + ' middle '.length + folderRef.token.length);
+  });
+
+  it('ignores a token embedded in a longer word', () => {
+    const text = `xx${fileRef.token}xx`;
+    expect(findReferenceRanges(text, [fileRef])).toHaveLength(0);
+  });
+
+  it('returns every standalone occurrence of a token', () => {
+    const text = `${fileRef.token} and ${fileRef.token}`;
+    const ranges = findReferenceRanges(text, [fileRef]);
+    expect(ranges).toHaveLength(2);
+    expect(ranges[1].from).toBeGreaterThan(ranges[0].to);
+  });
+
+  it('ignores tokens with no text', () => {
+    expect(findReferenceRanges('anything', [{ token: '', path: '', kind: 'file' }])).toHaveLength(0);
+  });
+});
+
+describe('findAtomicDeleteRange', () => {
+  const text = `start ${fileRef.token} end`;
+
+  it('backspace at the chip end removes the whole token', () => {
+    const target = findAtomicDeleteRange(text, [fileRef], {
+      key: 'Backspace',
+      selectionFrom: 6 + fileRef.token.length,
+      selectionTo: 6 + fileRef.token.length,
+    });
+    expect(target).toMatchObject({ from: 6, to: 6 + fileRef.token.length });
+  });
+
+  it('delete at the chip start removes the whole token', () => {
+    const target = findAtomicDeleteRange(text, [fileRef], {
+      key: 'Delete',
+      selectionFrom: 6,
+      selectionTo: 6,
+    });
+    expect(target).toMatchObject({ from: 6, to: 6 + fileRef.token.length });
+  });
+
+  it('returns null when the caret is away from the chip', () => {
+    expect(
+      findAtomicDeleteRange(text, [fileRef], { key: 'Backspace', selectionFrom: 2, selectionTo: 2 }),
+    ).toBeNull();
+  });
+
+  it('removes a chip overlapping a range selection', () => {
+    const target = findAtomicDeleteRange(text, [fileRef], {
+      key: 'Backspace',
+      selectionFrom: 8,
+      selectionTo: 12,
+    });
+    expect(target).toMatchObject({ from: 6, to: 6 + fileRef.token.length });
+  });
+
+  it('returns null when the selection does not overlap any chip', () => {
+    expect(
+      findAtomicDeleteRange(text, [fileRef], { key: 'Delete', selectionFrom: 0, selectionTo: 3 }),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/features/chat/ui/vault-drop.test.ts
+++ b/tests/unit/features/chat/ui/vault-drop.test.ts
@@ -177,6 +177,26 @@ describe('VaultDropController', () => {
 
       expect(seen).toEqual(['input']);
     });
+
+    it('reports inserted references so they can be chipified', () => {
+      const app = createApp({ type: 'files', files: [makeFile('a b.md'), makeFolder('dir')] });
+      const onInsertReference = jest.fn();
+      new VaultDropController(app, wrapper, inputEl, { onInsertReference });
+
+      wrapper.dispatchEvent('drop', createDropEvent());
+
+      expect(onInsertReference).toHaveBeenCalledTimes(2);
+      expect(onInsertReference).toHaveBeenNthCalledWith(1, {
+        token: '@a b.md',
+        path: 'a b.md',
+        kind: 'file',
+      });
+      expect(onInsertReference).toHaveBeenNthCalledWith(2, {
+        token: '@dir/',
+        path: 'dir',
+        kind: 'folder',
+      });
+    });
   });
 
   describe('overlay visibility', () => {

--- a/tests/unit/shared/markdown/mention-chip.test.ts
+++ b/tests/unit/shared/markdown/mention-chip.test.ts
@@ -1,0 +1,127 @@
+import type { App, TAbstractFile } from 'obsidian';
+import { TFile, TFolder } from 'obsidian';
+
+import {
+  findMentionCandidates,
+  formatReferenceLabel,
+  replaceMentionTokensWithHtml,
+} from '@/shared/markdown/mention-chip';
+
+function createMockApp(files: string[] = [], folders: string[] = []): App {
+  const entries = new Map<string, TAbstractFile>();
+  for (const path of files) {
+    const file = new TFile();
+    file.path = path;
+    entries.set(path, file);
+  }
+  for (const path of folders) {
+    const folder = new TFolder();
+    folder.path = path;
+    entries.set(path, folder);
+  }
+  return {
+    vault: {
+      getAbstractFileByPath: (path: string) => entries.get(path) ?? null,
+    },
+  } as unknown as App;
+}
+
+describe('formatReferenceLabel', () => {
+  it('uses the basename as the label', () => {
+    expect(formatReferenceLabel('folder/note.md')).toBe('note.md');
+  });
+
+  it('truncates long basenames with an ellipsis', () => {
+    const longName = 'a'.repeat(30);
+    expect(formatReferenceLabel(`folder/${longName}`)).toBe(`${'a'.repeat(20)}…`);
+  });
+});
+
+describe('findMentionCandidates', () => {
+  it('finds a path token surrounded by whitespace', () => {
+    const candidates = findMentionCandidates('look at @notes/idea.md now');
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({ path: 'notes/idea.md', start: 8, end: 22 });
+  });
+
+  it('requires a whitespace boundary before the @', () => {
+    expect(findMentionCandidates('mail me user@example.com')).toHaveLength(0);
+  });
+
+  it('strips trailing punctuation from the token', () => {
+    const candidates = findMentionCandidates('see @notes/idea.md, thanks');
+    expect(candidates[0]).toMatchObject({ path: 'notes/idea.md', end: 18 });
+  });
+
+  it('keeps folder tokens as folder paths', () => {
+    const candidates = findMentionCandidates('scan @projects/ for me');
+    expect(candidates[0]).toMatchObject({ path: 'projects', hasTrailingSlash: true });
+  });
+
+  it('ignores a bare @', () => {
+    expect(findMentionCandidates('just an @ alone')).toHaveLength(0);
+  });
+});
+
+describe('replaceMentionTokensWithHtml', () => {
+  it('replaces a file token that exists in the vault', () => {
+    const app = createMockApp(['notes/idea.md']);
+    const result = replaceMentionTokensWithHtml('check @notes/idea.md please', app);
+
+    expect(result).toContain('qoderian-msg-reference');
+    expect(result).toContain('data-kind="file"');
+    expect(result).toContain('data-path="notes/idea.md"');
+    expect(result).toContain('idea.md');
+    expect(result).toContain('title="@notes/idea.md"');
+    expect(result).toContain('check ');
+    expect(result).toContain(' please');
+  });
+
+  it('renders folder tokens with folder kind and slash in title', () => {
+    const app = createMockApp([], ['projects']);
+    const result = replaceMentionTokensWithHtml('scan @projects/ now', app);
+
+    expect(result).toContain('data-kind="folder"');
+    expect(result).toContain('title="@projects/"');
+  });
+
+  it('leaves unknown tokens untouched', () => {
+    const app = createMockApp(['notes/idea.md']);
+    const result = replaceMentionTokensWithHtml('see @missing/note.md now', app);
+
+    expect(result).toBe('see @missing/note.md now');
+  });
+
+  it('skips tokens inside code fences and inline code', () => {
+    const app = createMockApp(['notes/idea.md']);
+    const markdown = [
+      'before @notes/idea.md',
+      '```ts',
+      'const x = "@notes/idea.md";',
+      '```',
+      'inline `@notes/idea.md` code',
+    ].join('\n');
+    const result = replaceMentionTokensWithHtml(markdown, app);
+
+    expect(result.match(/qoderian-msg-reference/g)).toHaveLength(1);
+    expect(result).toContain('const x = "@notes/idea.md";');
+    expect(result).toContain('inline `@notes/idea.md` code');
+  });
+
+  it('escapes html in paths and labels', () => {
+    const app = createMockApp(['notes/a<b&c.md']);
+    const result = replaceMentionTokensWithHtml('open @notes/a<b&c.md now', app);
+
+    expect(result).toContain('data-path="notes/a&lt;b&amp;c.md"');
+  });
+
+  it('returns the input when there is no @ at all', () => {
+    const app = createMockApp(['notes/idea.md']);
+    expect(replaceMentionTokensWithHtml('plain text', app)).toBe('plain text');
+  });
+
+  it('handles text without a vault', () => {
+    const app = {} as App;
+    expect(replaceMentionTokensWithHtml('see @notes/idea.md', app)).toBe('see @notes/idea.md');
+  });
+});

--- a/tests/unit/shared/markdown/mention-chip.test.ts
+++ b/tests/unit/shared/markdown/mention-chip.test.ts
@@ -38,6 +38,12 @@ describe('formatReferenceLabel', () => {
 });
 
 describe('findMentionCandidates', () => {
+  it('resolves spaced paths when a resolver is provided', () => {
+    const candidates = findMentionCandidates('a @my notes/file.md b', (p) => p === 'my notes/file.md');
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].path).toBe('my notes/file.md');
+  });
   it('finds a path token surrounded by whitespace', () => {
     const candidates = findMentionCandidates('look at @notes/idea.md now');
     expect(candidates).toHaveLength(1);
@@ -123,5 +129,39 @@ describe('replaceMentionTokensWithHtml', () => {
   it('handles text without a vault', () => {
     const app = {} as App;
     expect(replaceMentionTokensWithHtml('see @notes/idea.md', app)).toBe('see @notes/idea.md');
+  });
+
+  describe('paths containing spaces', () => {
+    it('chipifies a spaced file path via longest-match shrinking', () => {
+      const app = createMockApp(['00-入口/Qoderian 宣传文档.md']);
+      const result = replaceMentionTokensWithHtml('看 @00-入口/Qoderian 宣传文档.md 谢谢', app);
+
+      expect(result).toContain('data-path="00-入口/Qoderian 宣传文档.md"');
+      expect(result).toContain('谢谢');
+    });
+
+    it('does not swallow the following sentence when only a shorter path exists', () => {
+      const app = createMockApp(['notes/idea.md']);
+      const result = replaceMentionTokensWithHtml('see @notes/idea.md and summarize', app);
+
+      expect(result).toContain('data-path="notes/idea.md"');
+      expect(result).toContain(' and summarize');
+    });
+
+    it('keeps later mentions when an earlier span does not resolve', () => {
+      const app = createMockApp(['notes/idea.md']);
+      const result = replaceMentionTokensWithHtml('@missing one two @notes/idea.md', app);
+
+      expect(result.match(/qoderian-msg-reference/g)).toHaveLength(1);
+      expect(result).toContain('@missing one two');
+    });
+
+    it('resolves spaced folder tokens', () => {
+      const app = createMockApp([], ['my projects']);
+      const result = replaceMentionTokensWithHtml('scan @my projects/ now', app);
+
+      expect(result).toContain('data-kind="folder"');
+      expect(result).toContain('data-path="my projects"');
+    });
   });
 });

--- a/tests/unit/shared/obsidian/compat.test.ts
+++ b/tests/unit/shared/obsidian/compat.test.ts
@@ -1,6 +1,6 @@
-import type { Workspace, WorkspaceLeaf } from 'obsidian';
+import type { App, TAbstractFile, Workspace, WorkspaceLeaf } from 'obsidian';
 
-import { revealWorkspaceLeaf } from '@/shared/obsidian/compat';
+import { openReferenceChip, revealWorkspaceLeaf } from '@/shared/obsidian/compat';
 
 describe('obsidianCompat', () => {
   describe('revealWorkspaceLeaf', () => {
@@ -13,6 +13,91 @@ describe('obsidianCompat', () => {
       await revealWorkspaceLeaf(workspace, leaf);
 
       expect((workspace as unknown as { revealLeaf: jest.Mock }).revealLeaf).toHaveBeenCalledWith(leaf);
+    });
+  });
+
+  describe('openReferenceChip', () => {
+    function createMockFile(path: string): TAbstractFile {
+      return { path, basename: path.split('/').pop() ?? path } as unknown as TAbstractFile;
+    }
+
+    function createMockFolder(path: string): TAbstractFile {
+      return { path, name: path.split('/').pop() ?? path, children: [] } as unknown as TAbstractFile;
+    }
+
+    function createMockApp(entries: Record<string, TAbstractFile>): {
+      app: App;
+      openFile: jest.Mock;
+      revealInFolder: jest.Mock;
+    } {
+      const openFile = jest.fn().mockResolvedValue(undefined);
+      const revealInFolder = jest.fn();
+      const app = {
+        vault: {
+          getAbstractFileByPath: (path: string) => entries[path] ?? null,
+        },
+        workspace: {
+          getLeaf: () => ({ openFile }),
+        },
+        internalPlugins: {
+          getPluginById: (id: string) => (
+            id === 'file-explorer' ? { instance: { revealInFolder } } : undefined
+          ),
+        },
+      } as unknown as App;
+      return { app, openFile, revealInFolder };
+    }
+
+    it('opens a file in a leaf when the kind is file', async () => {
+      const entry = createMockFile('notes/idea.md');
+      const { app, openFile, revealInFolder } = createMockApp({ 'notes/idea.md': entry });
+
+      openReferenceChip(app, 'file', 'notes/idea.md');
+      await Promise.resolve();
+
+      expect(openFile).toHaveBeenCalledWith(entry);
+      expect(revealInFolder).not.toHaveBeenCalled();
+    });
+
+    it('reveals a folder in the file explorer when the kind is folder', () => {
+      const entry = createMockFolder('projects');
+      const { app, openFile, revealInFolder } = createMockApp({ projects: entry });
+
+      openReferenceChip(app, 'folder', 'projects');
+
+      expect(revealInFolder).toHaveBeenCalledWith(entry);
+      expect(openFile).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the real type when the file kind is stale', () => {
+      // The path used to be a file but is a folder now (or vice versa).
+      const entry = createMockFolder('renamed/dir');
+      const { app, openFile, revealInFolder } = createMockApp({ 'renamed/dir': entry });
+
+      openReferenceChip(app, 'file', 'renamed/dir');
+
+      expect(revealInFolder).toHaveBeenCalledWith(entry);
+      expect(openFile).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the real type when the folder kind is stale', async () => {
+      const entry = createMockFile('renamed/note.md');
+      const { app, openFile, revealInFolder } = createMockApp({ 'renamed/note.md': entry });
+
+      openReferenceChip(app, 'folder', 'renamed/note.md');
+      await Promise.resolve();
+
+      expect(openFile).toHaveBeenCalledWith(entry);
+      expect(revealInFolder).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the path no longer exists', () => {
+      const { app, openFile, revealInFolder } = createMockApp({});
+
+      openReferenceChip(app, 'file', 'gone/note.md');
+
+      expect(openFile).not.toHaveBeenCalled();
+      expect(revealInFolder).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Renders `@file` / `@folder/` mention tokens as inline chips in the chat composer (CodeMirror-based `LiveComposer` behind a hidden-textarea `ComposerBridge`, so all existing input consumers keep working unchanged) and in sent message bubbles.
- Chips open the referenced note/folder on plain click on both surfaces (typed dispatch with stale-kind fallback and reveal flash); composer chips also carry a × remove button that deletes the whole token atomically, matching Backspace behavior.
- Fixes bubble-side tokenization to resolve paths containing spaces via longest-match vault verification instead of truncating at the first whitespace.
- Vault drops are claimed in the capture phase so CodeMirror never pastes the OS-level `obsidian://open` URI next to the mention, and dropped references register through `FileContextManager` so they chipify exactly like dropdown insertions.
- Needed so composer/bubble references read as first-class context objects (aligned with the Qoder IDE) instead of raw `@path` text, especially for CJK vaults where spaced filenames are common.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (3400 tests)
- [x] `npm run build`
- [x] `npm run release:check`
- [x] `npm run audit:prod`
- [x] Verified end-to-end in a real vault: chip rendering from dropdown/paste, plain-click open, × removal without navigation, spaced-path bubble chips, and no URI leak on drop

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible changes are documented in `CHANGELOG.md`