### PR TITLE
refactor: clear strict-review findings in composer bridge and settings tab

### DIFF
--- a/src/features/chat/ui/composer/composer-bridge.ts
+++ b/src/features/chat/ui/composer/composer-bridge.ts
@@ -142,45 +142,48 @@ export class ComposerBridge {
   };
 
   private installSourceInterceptors(): void {
-    const nativeValueGet = this.descriptors.value.get!;
-    const nativeValueSet = this.descriptors.value.set!;
-    const nativeSelectionStartGet = this.descriptors.selectionStart.get!;
-    const nativeSelectionStartSet = this.descriptors.selectionStart.set!;
-    const nativeSelectionEndGet = this.descriptors.selectionEnd.get!;
-    const nativeSelectionEndSet = this.descriptors.selectionEnd.set!;
-    const nativePlaceholderGet = this.descriptors.placeholder.get!;
-    const nativePlaceholderSet = this.descriptors.placeholder.set!;
     const sourceEl = this.sourceEl;
+    // Bind the native accessors to the element up front: they must always run
+    // with the textarea as `this`, and the bound references carry precise
+    // types instead of the descriptors' `any` signatures.
+    const nativeValueGet = this.descriptors.value.get!.bind(sourceEl) as () => string;
+    const nativeValueSet = this.descriptors.value.set!.bind(sourceEl) as (value: string) => void;
+    const nativeSelectionStartGet = this.descriptors.selectionStart.get!.bind(sourceEl) as () => number;
+    const nativeSelectionStartSet = this.descriptors.selectionStart.set!.bind(sourceEl) as (position: number | null) => void;
+    const nativeSelectionEndGet = this.descriptors.selectionEnd.get!.bind(sourceEl) as () => number;
+    const nativeSelectionEndSet = this.descriptors.selectionEnd.set!.bind(sourceEl) as (position: number | null) => void;
+    const nativePlaceholderGet = this.descriptors.placeholder.get!.bind(sourceEl) as () => string;
+    const nativePlaceholderSet = this.descriptors.placeholder.set!.bind(sourceEl) as (value: string) => void;
 
     Object.defineProperty(sourceEl, 'value', {
       configurable: true,
-      get: () => nativeValueGet.call(sourceEl),
+      get: () => nativeValueGet(),
       set: (value: string) => {
-        nativeValueSet.call(sourceEl, value);
+        nativeValueSet(value);
         this.syncComposerFromSource();
       },
     });
     Object.defineProperty(sourceEl, 'selectionStart', {
       configurable: true,
-      get: () => nativeSelectionStartGet.call(sourceEl),
+      get: () => nativeSelectionStartGet(),
       set: (position: number | null) => {
-        nativeSelectionStartSet.call(sourceEl, position);
+        nativeSelectionStartSet(position);
         this.syncComposerSelectionFromSource();
       },
     });
     Object.defineProperty(sourceEl, 'selectionEnd', {
       configurable: true,
-      get: () => nativeSelectionEndGet.call(sourceEl),
+      get: () => nativeSelectionEndGet(),
       set: (position: number | null) => {
-        nativeSelectionEndSet.call(sourceEl, position);
+        nativeSelectionEndSet(position);
         this.syncComposerSelectionFromSource();
       },
     });
     Object.defineProperty(sourceEl, 'placeholder', {
       configurable: true,
-      get: () => nativePlaceholderGet.call(sourceEl),
+      get: () => nativePlaceholderGet(),
       set: (value: string) => {
-        nativePlaceholderSet.call(sourceEl, value);
+        nativePlaceholderSet(value);
         if (!this.destroyed) this.composer.setPlaceholder(value);
       },
     });

--- a/src/features/settings/settings-tab.ts
+++ b/src/features/settings/settings-tab.ts
@@ -480,11 +480,16 @@ export class QoderianSettingTab extends PluginSettingTab {
   }
 
   /**
-   * Imperative renderer for Obsidian versions older than 1.13.0, which
+   * Imperative entry point for Obsidian versions older than 1.13.0, which
    * never consult getSettingDefinitions(). Kept as the documented fallback
    * and sharing the same builders as the declarative render rows.
    */
   display(): void {
+    this.renderLegacySettings();
+  }
+
+  /** Rebuilds the legacy page; re-invoked directly after a locale change. */
+  private renderLegacySettings(): void {
     const { containerEl } = this;
     containerEl.empty();
     containerEl.addClass('qoderian-settings');
@@ -536,7 +541,7 @@ export class QoderianSettingTab extends PluginSettingTab {
             }
             this.plugin.settings.locale = locale;
             await this.plugin.saveSettings();
-            this.display();
+            this.renderLegacySettings();
             this.refreshViewChrome();
           });
       });


### PR DESCRIPTION
## Summary

- Clears the strict-review findings reported on main (c4c6fd2):
  - **ComposerBridge**: native textarea accessors were extracted as bare references (`unbound-method`) and their `any` returns leaked through the interceptor getters (`no-unsafe-return`). They are now bound to the element up front and typed precisely (`() => string`, `(v: string) => void`, ...), which is both the rule-recommended pattern and semantically exact — native accessors must run with the textarea as `this`.
  - **Settings tab**: the pre-1.13 legacy fallback refreshed after a locale change via a deprecated `this.display()` self-call. The page build now lives in a private `renderLegacySettings()`; `display()` delegates to it and the locale change handler calls it directly. Behavior on Obsidian < 1.13 is unchanged; the 1.13+ declarative path was already refresh-safe via `setControlValue`.

## Verification

- [x] Ad-hoc eslint run with `@typescript-eslint/unbound-method` and `@typescript-eslint/no-unsafe-return` enabled as errors: 12 errors before the change, 0 after
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (3411 tests)
- [x] `npm run build`
- [x] `npm run release:check`

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] No user-visible behavior change; no CHANGELOG entry needed
