### PR TITLE
fix(settings): refresh language row labels on live locale switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ coverage/
 
 # Temporary screenshots from automated UI verification
 /.cu_crop_*.png
+/.verify-shots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ version with its date and start a fresh empty `[Unreleased]` above it.
   mentions just like notes (chipified, no attachment preview); mixed
   drags combine note, folder, and image mentions, and only truly
   unsupported file types are reported as ignored.
+- The settings language row now updates its own label and description
+  immediately when the display language is changed, instead of keeping
+  the previous language's text until the settings tab is reopened.
 
 ## [1.0.5] - 2026-08-18
 

--- a/src/features/settings/settings-tab.ts
+++ b/src/features/settings/settings-tab.ts
@@ -438,8 +438,11 @@ export class QoderianSettingTab extends PluginSettingTab {
       await this.plugin.saveSettings();
 
       if (key === 'locale') {
+        const previousName = t('settings.language.name');
+        const previousDesc = t('settings.language.desc');
         setLocale(this.plugin.settings.locale as Locale);
         this.update();
+        this.refreshLocalizedLanguageRow(previousName, previousDesc);
         this.refreshViewChrome();
       } else if (key === 'maxTabs') {
         for (const view of this.plugin.getAllViews()) {
@@ -457,6 +460,26 @@ export class QoderianSettingTab extends PluginSettingTab {
   private refreshViewChrome(): void {
     for (const view of this.plugin.getAllViews()) {
       view.refreshLocalizedChrome();
+    }
+  }
+
+  /**
+   * Obsidian's declarative reconciler refreshes every row except the one
+   * whose control triggered the change, so after a live language switch the
+   * language row would keep the previous locale's labels until the tab is
+   * reopened. Patch its leaf text nodes directly; any later full render
+   * produces the same strings, so this cannot conflict.
+   */
+  private refreshLocalizedLanguageRow(previousName: string, previousDesc: string): void {
+    const newName = t('settings.language.name');
+    const newDesc = t('settings.language.desc');
+    for (const el of Array.from(this.containerEl.querySelectorAll('*'))) {
+      if (el.children.length !== 0) continue;
+      if (el.textContent === previousName) {
+        el.setText(newName);
+      } else if (el.textContent === previousDesc) {
+        el.setText(newDesc);
+      }
     }
   }
 

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -24,6 +24,7 @@ export class PluginSettingTab {
     empty: jest.fn(),
     createEl: jest.fn().mockReturnValue({ createEl: jest.fn(), createDiv: jest.fn() }),
     createDiv: jest.fn().mockReturnValue({ createEl: jest.fn(), createDiv: jest.fn() }),
+    querySelectorAll: jest.fn().mockReturnValue([]),
   };
 
   constructor(app: any, plugin: any) {


### PR DESCRIPTION
## Summary

- Fixes the stale language row on live locale switch (Obsidian 1.13+ declarative settings): Obsidian's declarative reconciler re-renders every settings row except the one whose control triggered the change, so after switching the display language the language row kept the previous locale's name/description until the settings tab was reopened.
- After `setControlValue('locale')` persists and calls `update()`, the tab now also patches the language row's leaf text nodes directly with the new locale's strings. Any later full render produces the same strings, so this cannot conflict with the reconciler.
- Legacy (<1.13) path unchanged; it already re-rendered via `renderLegacySettings()`.
- Adds `querySelectorAll` to the mocked `PluginSettingTab.containerEl` and a CHANGELOG entry; ignores the `.verify-shots/` scratch dir.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (3411 tests)
- [x] `npm run build`
- [x] `npm run release:check`
- [x] Real-device E2E in test vault: zh-CN → English → zh-CN, the language row's own label/description refresh immediately on both switches (screenshots verified), no layout regression

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible change documented in `CHANGELOG.md`
