### PR TITLE
fix(chat): steer interrupts the in-flight turn; silence aborted receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ coverage/
 # Temporary screenshots from automated UI verification
 /.cu_crop_*.png
 /.verify-shots/
+/.cu_tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ version with its date and start a fresh empty `[Unreleased]` above it.
   delete actions, and entries drain one per turn end in FIFO order.
 - Steer an in-flight turn from the send queue (Codex-style): while a
   response is streaming, each queued entry without images gains a Steer
-  action that injects it into the running turn at the next step boundary,
-  rendering it as a user message immediately instead of waiting for the
+  action that interrupts the running turn and handles the message
+  immediately, rendering it as a user message instead of waiting for the
   turn to end.
 - Drag notes or folders from the Obsidian file explorer into the chat
   composer: they are inserted as `@note` / `@folder/` context mentions at
@@ -58,6 +58,14 @@ version with its date and start a fresh empty `[Unreleased]` above it.
 - The settings language row now updates its own label and description
   immediately when the display language is changed, instead of keeping
   the previous language's text until the settings tab is reopened.
+- Steering an in-flight turn now interrupts it immediately instead of
+  queuing the message as a follow-up turn that only arrives after the
+  running response finishes, and the interrupted turn no longer shows an
+  error receipt.
+- Send failure paths (agent service unavailable or initialization
+  failure) now fully clean up the streaming state and queue indicator,
+  so the composer no longer stays stuck as "streaming" after an early
+  send error.
 
 ## [1.0.5] - 2026-08-18
 

--- a/src/features/chat/controllers/input-controller.ts
+++ b/src/features/chat/controllers/input-controller.ts
@@ -559,8 +559,9 @@ export class InputController {
 
   /**
    * Codex-style steering: inject a queued turn into the in-flight turn. The
-   * CLI applies it at the next step boundary. Returns false when steering is
-   * not possible right now; the message should stay queued then.
+   * CLI interrupts the active turn and handles the text immediately
+   * (`priority: 'now'`). Returns false when steering is not possible right
+   * now; the message should stay queued then.
    */
   steerQueuedTurn(turn: QueuedChatTurn): boolean {
     if (!this.canSteerQueuedTurn()) return false;

--- a/src/features/chat/controllers/input-controller.ts
+++ b/src/features/chat/controllers/input-controller.ts
@@ -332,6 +332,9 @@ export class InputController {
         new Notice('Failed to initialize agent service. Please try again.');
         streamController.hideThinkingIndicator();
         state.isStreaming = false;
+        // Re-render the send queue so steer buttons drop now that the turn
+        // ended before it started (same contract as the normal exit path).
+        this.updateQueueIndicator();
         this.activeStreamingAssistantMessage = null;
         this.resetRuntimeMessageBoundaryState();
         return;
@@ -341,6 +344,9 @@ export class InputController {
     const agentService = this.getAgentService();
     if (!agentService) {
       new Notice('Agent service not available. Please reload the plugin.');
+      streamController.hideThinkingIndicator();
+      state.isStreaming = false;
+      this.updateQueueIndicator();
       this.activeStreamingAssistantMessage = null;
       this.resetRuntimeMessageBoundaryState();
       return;

--- a/src/qoder/runtime/qoder-chat-runtime.ts
+++ b/src/qoder/runtime/qoder-chat-runtime.ts
@@ -1163,8 +1163,9 @@ export class QoderChatRuntime implements ChatRuntime {
   }
 
   /**
-   * Inject a text message into the in-flight turn. The CLI applies it at the
-   * next step boundary (between tool calls). Fails when no turn is running.
+   * Inject a text message into the in-flight turn (steering). The channel
+   * stamps `priority: 'now'` so the CLI interrupts the active turn and
+   * handles the text immediately. Fails when no turn is running.
    */
   steerTurn(text: string): boolean {
     return this.messageChannel?.steer(text) ?? false;

--- a/src/qoder/runtime/qoder-message-channel.ts
+++ b/src/qoder/runtime/qoder-message-channel.ts
@@ -134,15 +134,19 @@ export class QoderMessageChannel implements AsyncIterable<SDKUserMessage> {
   }
 
   /**
-   * Deliver a text message into the in-flight turn (steering). The CLI picks
-   * it up at the next step boundary. Returns false when there is no active
-   * turn or no consumer waiting; callers should keep the message queued then.
+   * Deliver a text message into the in-flight turn (steering). The message
+   * carries `priority: 'now'` so the CLI interrupts the active turn and
+   * handles it immediately — without it the CLI defaults to 'next', queues
+   * the text as a follow-up turn, and the reply arrives long after, out of
+   * band. Returns false when there is no active turn or no consumer
+   * waiting; callers should keep the message queued then.
    */
   steer(text: string): boolean {
     if (this.closed || !this.turnActive || !this.resolveNext) return false;
     const resolve = this.resolveNext;
     this.resolveNext = null;
-    resolve({ value: this.pendingToMessage({ type: 'text', content: text }), done: false });
+    const message = this.pendingToMessage({ type: 'text', content: text });
+    resolve({ value: { ...message, priority: 'now' }, done: false });
     return true;
   }
 

--- a/src/qoder/runtime/qoder-response-router.ts
+++ b/src/qoder/runtime/qoder-response-router.ts
@@ -3,7 +3,7 @@ import { Notice } from 'obsidian';
 
 import type { AutoTurnCallback } from '../../core/runtime/types';
 import type { StreamChunk } from '../../core/types';
-import { transformSDKMessage } from '../stream/transform-qoder-message';
+import { isAbortedResult,transformSDKMessage } from '../stream/transform-qoder-message';
 import { isContextWindowEvent, isSessionInitEvent, isStreamChunk } from '../stream/type-guards';
 import type { SessionInitEvent } from '../stream/types';
 import { TOOL_ENTER_PLAN_MODE } from '../tools/tool-names';
@@ -160,7 +160,13 @@ export class QoderResponseRouter {
     if (handler) {
       handler.resetStreamText();
       handler.resetStreamThinking();
-      handler.onDone();
+      // A deliberately aborted turn (Esc or priority-'now' steer) is followed
+      // by its successor turn or by consumer teardown — never by session
+      // idle with the handler still waiting. Keep the handler alive so the
+      // successor's chunks keep streaming into the same turn generator.
+      if (!isAbortedResult(message)) {
+        handler.onDone();
+      }
     } else {
       await this.flushAutoTurnBuffer();
     }

--- a/src/qoder/stream/transform-qoder-message.ts
+++ b/src/qoder/stream/transform-qoder-message.ts
@@ -128,6 +128,22 @@ function isResultError(message: { type: 'result'; subtype: string }): message is
   return !!message.subtype && message.subtype !== 'success';
 }
 
+const ABORT_TERMINAL_REASONS = new Set(['aborted_streaming', 'aborted_tools']);
+
+/**
+ * A result whose `terminal_reason` marks a deliberate abort (Esc interrupt or
+ * a priority-'now' steer), per the CLI protocol. The CLI emits these as
+ * error_during_execution results, but they are cancellation receipts, not
+ * failures — the CLI's own headless consumer maps them to SIGINT's exit code.
+ */
+export function isAbortedResult(
+  message: { type: string; terminal_reason?: string | null },
+): boolean {
+  return message.type === 'result'
+    && !!message.terminal_reason
+    && ABORT_TERMINAL_REASONS.has(message.terminal_reason);
+}
+
 function normalizeQoderModelId(model: string): string {
   const normalized = model.trim().toLowerCase();
   const qoderIndex = normalized.indexOf('qoder-');
@@ -592,12 +608,18 @@ export function* transformSDKMessage(
         options.usageState.clear();
       }
       if (isResultError(message)) {
-        const errors = message.errors.filter((error) => error.trim().length > 0);
-        if (errors.length === 0) {
-          yield { type: 'error', content: `Result error: ${message.subtype}` };
+        if (isAbortedResult(message)) {
+          // Cancellation receipt, not a failure: render as a notice and let
+          // the router keep the turn stream alive for the successor turn.
+          yield { type: 'notice', content: 'Turn interrupted' };
         } else {
-          for (const error of errors) {
-            yield { type: 'error', content: error };
+          const errors = message.errors.filter((error) => error.trim().length > 0);
+          if (errors.length === 0) {
+            yield { type: 'error', content: `Result error: ${message.subtype}` };
+          } else {
+            for (const error of errors) {
+              yield { type: 'error', content: error };
+            }
           }
         }
       }

--- a/src/qoder/stream/transform-qoder-message.ts
+++ b/src/qoder/stream/transform-qoder-message.ts
@@ -607,19 +607,13 @@ export function* transformSDKMessage(
         }
         options.usageState.clear();
       }
-      if (isResultError(message)) {
-        if (isAbortedResult(message)) {
-          // Cancellation receipt, not a failure: render as a notice and let
-          // the router keep the turn stream alive for the successor turn.
-          yield { type: 'notice', content: 'Turn interrupted' };
+      if (isResultError(message) && !isAbortedResult(message)) {
+        const errors = message.errors.filter((error) => error.trim().length > 0);
+        if (errors.length === 0) {
+          yield { type: 'error', content: `Result error: ${message.subtype}` };
         } else {
-          const errors = message.errors.filter((error) => error.trim().length > 0);
-          if (errors.length === 0) {
-            yield { type: 'error', content: `Result error: ${message.subtype}` };
-          } else {
-            for (const error of errors) {
-              yield { type: 'error', content: error };
-            }
+          for (const error of errors) {
+            yield { type: 'error', content: error };
           }
         }
       }

--- a/tests/unit/qoder/runtime/qoder-message-channel.test.ts
+++ b/tests/unit/qoder/runtime/qoder-message-channel.test.ts
@@ -418,4 +418,52 @@ describe('QoderMessageChannel', () => {
       expect(channel.isTurnActive()).toBe(false);
     });
   });
+
+  describe('steer', () => {
+    it('delivers the text with priority now so the CLI interrupts the active turn', async () => {
+      const iterator = channel[Symbol.asyncIterator]();
+      const firstPromise = iterator.next();
+      channel.enqueue(createTextUserMessage('original'));
+      await firstPromise;
+
+      // The consumer waits for the next message while the turn is active.
+      const secondPromise = iterator.next();
+      await Promise.resolve();
+
+      expect(channel.steer('steered text')).toBe(true);
+
+      const steered = await secondPromise;
+      expect(steered.done).toBe(false);
+      expect(steered.value.type).toBe('user');
+      expect(steered.value.message.content).toBe('steered text');
+      // Without 'now' the CLI defaults to 'next' and defers the text as a
+      // follow-up turn instead of interrupting the in-flight one.
+      expect(steered.value.priority).toBe('now');
+    });
+
+    it('returns false when no turn is active', async () => {
+      const iterator = channel[Symbol.asyncIterator]();
+      const pending = iterator.next();
+      await Promise.resolve();
+
+      expect(channel.steer('ignored')).toBe(false);
+
+      // The rejected steer left the consumer waiting; a normal enqueue
+      // delivers without any priority stamp.
+      channel.enqueue(createTextUserMessage('follow-up'));
+      const result = await pending;
+      expect(result.value.message.content).toBe('follow-up');
+      expect(result.value.priority).toBeUndefined();
+    });
+
+    it('returns false when no consumer is waiting', async () => {
+      const iterator = channel[Symbol.asyncIterator]();
+      const firstPromise = iterator.next();
+      channel.enqueue(createTextUserMessage('original'));
+      await firstPromise;
+
+      // Turn is active but the consumer has not requested the next message.
+      expect(channel.steer('ignored')).toBe(false);
+    });
+  });
 });

--- a/tests/unit/qoder/runtime/qoder-response-router.test.ts
+++ b/tests/unit/qoder/runtime/qoder-response-router.test.ts
@@ -68,13 +68,12 @@ describe('QoderResponseRouter', () => {
       expect(events.onDone).toHaveBeenCalledTimes(1);
     });
 
-    it('routes the abort receipt to the handler as a notice chunk', async () => {
+    it('routes nothing to the handler for an abort receipt', async () => {
       const { router, chunks } = createRouterHarness();
 
       await router.route(buildAbortResult());
 
-      expect(chunks).toContainEqual({ type: 'notice', content: 'Turn interrupted' });
-      expect(chunks.filter(chunk => chunk.type === 'error')).toEqual([]);
+      expect(chunks).toEqual([]);
     });
 
     it('completes the handler for non-abort error results', async () => {

--- a/tests/unit/qoder/runtime/qoder-response-router.test.ts
+++ b/tests/unit/qoder/runtime/qoder-response-router.test.ts
@@ -1,0 +1,92 @@
+import type { SDKResultError } from '@qoder-ai/qoder-agent-sdk';
+import { buildSDKMessage } from '@test/helpers/sdk-messages';
+
+import type { StreamChunk } from '@/core/types';
+import { QoderResponseRouter } from '@/qoder/runtime/qoder-response-router';
+import { createResponseHandler } from '@/qoder/runtime/types';
+
+function createRouterHarness() {
+  const onTurnComplete = jest.fn();
+  const deps = {
+    turnTracker: {
+      getTransformOptions: () => ({}),
+      fetchContextUsage: async () => null,
+      bufferUsage: (chunk: StreamChunk) => chunk,
+      updateContextWindow: () => null,
+      record: jest.fn(),
+    },
+    getCurrentQuery: () => null,
+    getMessageChannel: () => ({ onTurnComplete }),
+    getConfiguredModel: () => 'qoder-sonnet-4-5',
+    getConfiguredContextWindow: () => undefined,
+    getSessionId: () => null,
+    onSessionInit: jest.fn(),
+    onPlanModeEntered: jest.fn(),
+  };
+  const router = new QoderResponseRouter(deps as never);
+
+  const chunks: StreamChunk[] = [];
+  const events = { onDone: jest.fn(), onError: jest.fn() };
+  const handler = createResponseHandler({
+    id: 'test-handler',
+    onChunk: chunk => chunks.push(chunk),
+    onDone: events.onDone,
+    onError: events.onError,
+  });
+  router.register(handler);
+
+  return { router, handler, chunks, events, onTurnComplete };
+}
+
+function buildAbortResult(): SDKResultError {
+  return buildSDKMessage({
+    type: 'result',
+    subtype: 'error_during_execution',
+    errors: ['Operation aborted'],
+    terminal_reason: 'aborted_streaming',
+  }) as SDKResultError;
+}
+
+describe('QoderResponseRouter', () => {
+  describe('aborted turn results', () => {
+    it('keeps the active handler alive so the successor turn keeps streaming', async () => {
+      const { router, events, onTurnComplete } = createRouterHarness();
+
+      await router.route(buildAbortResult());
+
+      expect(onTurnComplete).toHaveBeenCalledTimes(1);
+      expect(events.onDone).not.toHaveBeenCalled();
+    });
+
+    it('completes the handler on the successor turn result', async () => {
+      const { router, events } = createRouterHarness();
+
+      await router.route(buildAbortResult());
+      expect(events.onDone).not.toHaveBeenCalled();
+
+      await router.route(buildSDKMessage({ type: 'result', subtype: 'success' }));
+      expect(events.onDone).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes the abort receipt to the handler as a notice chunk', async () => {
+      const { router, chunks } = createRouterHarness();
+
+      await router.route(buildAbortResult());
+
+      expect(chunks).toContainEqual({ type: 'notice', content: 'Turn interrupted' });
+      expect(chunks.filter(chunk => chunk.type === 'error')).toEqual([]);
+    });
+
+    it('completes the handler for non-abort error results', async () => {
+      const { router, events } = createRouterHarness();
+
+      await router.route(buildSDKMessage({
+        type: 'result',
+        subtype: 'error_during_execution',
+        errors: ['Credit limit reached'],
+      }));
+
+      expect(events.onDone).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/qoder/stream/transform-qoder-message.test.ts
+++ b/tests/unit/qoder/stream/transform-qoder-message.test.ts
@@ -1175,6 +1175,48 @@ describe('transformSDKMessage', () => {
       ]);
     });
 
+    it('renders an aborted_streaming result as a notice, not an error', () => {
+      // Receipt for a deliberately interrupted turn (Esc or priority-'now' steer).
+      const message = msg({
+        type: 'result',
+        subtype: 'error_during_execution',
+        errors: ['Operation aborted'],
+        terminal_reason: 'aborted_streaming',
+      });
+
+      const results = [...transformSDKMessage(message)];
+
+      expect(results.filter(result => result.type === 'error')).toEqual([]);
+      expect(results).toContainEqual({ type: 'notice', content: 'Turn interrupted' });
+    });
+
+    it('renders an aborted_tools result as a notice, not an error', () => {
+      const message = msg({
+        type: 'result',
+        subtype: 'error_during_execution',
+        errors: ['Operation aborted'],
+        terminal_reason: 'aborted_tools',
+      });
+
+      const results = [...transformSDKMessage(message)];
+
+      expect(results.filter(result => result.type === 'error')).toEqual([]);
+      expect(results).toContainEqual({ type: 'notice', content: 'Turn interrupted' });
+    });
+
+    it('keeps error events for non-abort terminal reasons', () => {
+      const message = msg({
+        type: 'result',
+        subtype: 'error_during_execution',
+        errors: ['Something failed'],
+        terminal_reason: 'something_else',
+      });
+
+      const results = [...transformSDKMessage(message)];
+
+      expect(results).toContainEqual({ type: 'error', content: 'Something failed' });
+    });
+
     it('yields context_window with 1M for [1m] models', () => {
       const message = msg({
         type: 'result',

--- a/tests/unit/qoder/stream/transform-qoder-message.test.ts
+++ b/tests/unit/qoder/stream/transform-qoder-message.test.ts
@@ -1175,8 +1175,9 @@ describe('transformSDKMessage', () => {
       ]);
     });
 
-    it('renders an aborted_streaming result as a notice, not an error', () => {
-      // Receipt for a deliberately interrupted turn (Esc or priority-'now' steer).
+    it('stays silent for an aborted_streaming result', () => {
+      // Receipt for a deliberately interrupted turn (Esc or priority-'now' steer);
+      // the user already saw the interruption, no bubble output is wanted.
       const message = msg({
         type: 'result',
         subtype: 'error_during_execution',
@@ -1186,11 +1187,10 @@ describe('transformSDKMessage', () => {
 
       const results = [...transformSDKMessage(message)];
 
-      expect(results.filter(result => result.type === 'error')).toEqual([]);
-      expect(results).toContainEqual({ type: 'notice', content: 'Turn interrupted' });
+      expect(results.filter(result => result.type === 'error' || result.type === 'notice')).toEqual([]);
     });
 
-    it('renders an aborted_tools result as a notice, not an error', () => {
+    it('stays silent for an aborted_tools result', () => {
       const message = msg({
         type: 'result',
         subtype: 'error_during_execution',
@@ -1200,8 +1200,7 @@ describe('transformSDKMessage', () => {
 
       const results = [...transformSDKMessage(message)];
 
-      expect(results.filter(result => result.type === 'error')).toEqual([]);
-      expect(results).toContainEqual({ type: 'notice', content: 'Turn interrupted' });
+      expect(results.filter(result => result.type === 'error' || result.type === 'notice')).toEqual([]);
     });
 
     it('keeps error events for non-abort terminal reasons', () => {


### PR DESCRIPTION
Closes gaps found after the send-queue / steer work landed on main.

## Problems (verified on main)
1. **Steer did not actually interrupt**: `steer()` sent the queued text with the default `priority: 'next'`, so the CLI queued it as a *follow-up turn* — the in-flight response kept running to completion and the steered reply arrived long after, out of band (reproduced E2E: essay finished fully before PONG was handled).
2. **Interrupted turns surfaced error receipts**: the CLI reports deliberate aborts (`terminal_reason: aborted_streaming / aborted_tools`) as `error_during_execution` results, which the transform turned into error chunks/receipts for what is really a cancellation.
3. **Send early-returns leaked streaming state**: two early-return paths (agent init failure, agent service unavailable) skipped `hideThinkingIndicator` / `isStreaming=false` / queue indicator refresh, leaving the composer stuck as "streaming".

## Changes
- `qoder-message-channel.steer()` stamps `priority: 'now'` so the CLI interrupts the active turn and handles the text immediately (SDK contract: `'now'` interrupts, `'next'` injects at boundary).
- `transform-qoder-message`: new `isAbortedResult()` (matches the two abort terminal reasons); aborted results no longer yield error chunks.
- `qoder-response-router`: on turn-complete, skip `handler.onDone()` for aborted results so the successor turn's chunks keep streaming into the same handler (session-level teardown still calls `onDone` via `reset()`).
- `input-controller`: complete the streaming-state cleanup on both early-return paths.

## Verification
- Unit/integration: 3421 tests green (10 new covering abort routing/receipt silencing).
- Gates: typecheck, lint, release:check all green.
- E2E on device (branch build): steer stops the in-flight essay within seconds with no error receipt, PONG arrives as the immediate next response; Esc interrupt still clean (Interrupted marker, no error block); conversation usable afterwards.

Co-authored-by: QoderAI (Qwen 3.8 Max) <qoder_ai@qoder.com>
