### PR TITLE
fix(chat): resume paused queue after interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ version with its date and start a fresh empty `[Unreleased]` above it.
 - The steered reply streams incrementally again: the interrupted turn's
   receipt no longer triggers a context-usage request that stalled the
   response consumer, which made the whole reply appear only at the end.
+- Stopping a streaming turn (Stop or Esc) completes it again: the chat
+  leaves the streaming state and the paused send queue can be resumed,
+  instead of staying stuck until the next message. Steered turns keep
+  their live hand-off and are unaffected.
 
 ## [1.0.5] - 2026-08-18
 

--- a/src/qoder/runtime/qoder-message-channel.ts
+++ b/src/qoder/runtime/qoder-message-channel.ts
@@ -28,6 +28,7 @@ export class QoderMessageChannel implements AsyncIterable<SDKUserMessage> {
   private closed = false;
   private resolveNext: ((value: IteratorResult<SDKUserMessage>) => void) | null = null;
   private currentSessionId: string | null = null;
+  private pendingSteerAborts = 0;
   private onWarning: (message: string) => void;
 
   constructor(onWarning: (message: string) => void = () => {}) {
@@ -123,6 +124,7 @@ export class QoderMessageChannel implements AsyncIterable<SDKUserMessage> {
 
   onTurnComplete(): void {
     this.turnActive = false;
+    this.pendingSteerAborts = 0;
 
     if (this.queue.length > 0 && this.resolveNext) {
       const pending = this.queue.shift()!;
@@ -146,13 +148,22 @@ export class QoderMessageChannel implements AsyncIterable<SDKUserMessage> {
     const resolve = this.resolveNext;
     this.resolveNext = null;
     const message = this.pendingToMessage({ type: 'text', content: text });
+    this.pendingSteerAborts += 1;
     resolve({ value: { ...message, priority: 'now' }, done: false });
+    return true;
+  }
+
+  /** Consume one abort receipt expected from a priority-'now' steer. */
+  consumeSteerAbort(): boolean {
+    if (this.pendingSteerAborts === 0) return false;
+    this.pendingSteerAborts -= 1;
     return true;
   }
 
   close(): void {
     this.closed = true;
     this.queue = [];
+    this.pendingSteerAborts = 0;
     if (this.resolveNext) {
       const resolve = this.resolveNext;
       this.resolveNext = null;
@@ -165,6 +176,7 @@ export class QoderMessageChannel implements AsyncIterable<SDKUserMessage> {
     this.turnActive = false;
     this.closed = false;
     this.resolveNext = null;
+    this.pendingSteerAborts = 0;
   }
 
   getQueueLength(): number {

--- a/src/qoder/runtime/qoder-response-router.ts
+++ b/src/qoder/runtime/qoder-response-router.ts
@@ -155,6 +155,13 @@ export class QoderResponseRouter {
     if (isAbortedResult(message)) {
       handler?.resetStreamText();
       handler?.resetStreamThinking();
+      if (this.deps.getMessageChannel()?.consumeSteerAbort()) return;
+
+      // A plain user interrupt has no successor. Complete the active handler
+      // so the UI leaves streaming state and a paused queue can be resumed.
+      this.deps.getMessageChannel()?.onTurnComplete();
+      if (handler) handler.onDone();
+      else await this.flushAutoTurnBuffer();
       return;
     }
 

--- a/tests/unit/qoder/runtime/qoder-message-channel.test.ts
+++ b/tests/unit/qoder/runtime/qoder-message-channel.test.ts
@@ -439,6 +439,29 @@ describe('QoderMessageChannel', () => {
       // Without 'now' the CLI defaults to 'next' and defers the text as a
       // follow-up turn instead of interrupting the in-flight one.
       expect(steered.value.priority).toBe('now');
+      expect(channel.consumeSteerAbort()).toBe(true);
+      expect(channel.consumeSteerAbort()).toBe(false);
+    });
+
+    it('tracks multiple abort receipts independently', async () => {
+      const iterator = channel[Symbol.asyncIterator]();
+      const firstPromise = iterator.next();
+      channel.enqueue(createTextUserMessage('original'));
+      await firstPromise;
+
+      const secondPromise = iterator.next();
+      await Promise.resolve();
+      expect(channel.steer('first steer')).toBe(true);
+      await secondPromise;
+
+      const thirdPromise = iterator.next();
+      await Promise.resolve();
+      expect(channel.steer('second steer')).toBe(true);
+      await thirdPromise;
+
+      expect(channel.consumeSteerAbort()).toBe(true);
+      expect(channel.consumeSteerAbort()).toBe(true);
+      expect(channel.consumeSteerAbort()).toBe(false);
     });
 
     it('returns false when no turn is active', async () => {

--- a/tests/unit/qoder/runtime/qoder-response-router.test.ts
+++ b/tests/unit/qoder/runtime/qoder-response-router.test.ts
@@ -5,8 +5,9 @@ import type { StreamChunk } from '@/core/types';
 import { QoderResponseRouter } from '@/qoder/runtime/qoder-response-router';
 import { createResponseHandler } from '@/qoder/runtime/types';
 
-function createRouterHarness() {
+function createRouterHarness(options: { pendingSteerAbort?: boolean } = {}) {
   const onTurnComplete = jest.fn();
+  const consumeSteerAbort = jest.fn().mockReturnValue(options.pendingSteerAbort ?? true);
   const fetchContextUsage = jest.fn().mockResolvedValue(null);
   const deps = {
     turnTracker: {
@@ -17,7 +18,7 @@ function createRouterHarness() {
       record: jest.fn(),
     },
     getCurrentQuery: () => null,
-    getMessageChannel: () => ({ onTurnComplete }),
+    getMessageChannel: () => ({ consumeSteerAbort, onTurnComplete }),
     getConfiguredModel: () => 'qoder-sonnet-4-5',
     getConfiguredContextWindow: () => undefined,
     getSessionId: () => null,
@@ -36,7 +37,7 @@ function createRouterHarness() {
   });
   router.register(handler);
 
-  return { router, handler, chunks, events, fetchContextUsage, onTurnComplete };
+  return { router, handler, chunks, consumeSteerAbort, events, fetchContextUsage, onTurnComplete };
 }
 
 function buildAbortResult(): SDKResultError {
@@ -65,6 +66,18 @@ describe('QoderResponseRouter', () => {
       await router.route(buildAbortResult());
 
       expect(fetchContextUsage).not.toHaveBeenCalled();
+    });
+
+    it('completes the handler for a plain user interrupt with no successor', async () => {
+      const { router, events, fetchContextUsage, onTurnComplete } = createRouterHarness({
+        pendingSteerAbort: false,
+      });
+
+      await router.route(buildAbortResult());
+
+      expect(fetchContextUsage).not.toHaveBeenCalled();
+      expect(onTurnComplete).toHaveBeenCalledTimes(1);
+      expect(events.onDone).toHaveBeenCalledTimes(1);
     });
 
     it('completes the handler on the successor turn result', async () => {


### PR DESCRIPTION
## Summary

- Fix "interrupted turn never completes": after #41, both steer aborts and plain Stop/Esc interrupts kept the response handler alive (waiting for a successor turn), so a plain interrupt left the chat stuck in streaming state and the paused send queue could not be resumed.
- Root cause: the aborted receipt path in `QoderResponseRouter` cannot tell a steer abort (has a successor) from a plain user interrupt (no successor) by the receipt alone.
- Fix: `QoderMessageChannel` now counts expected steer abort receipts (`pendingSteerAborts`, bumped in `steer()`, cleared on `onTurnComplete()` / `close()` / `reset()`). The router consumes one receipt per aborted result: if a steer credit exists the successor hand-off is preserved; otherwise it completes the turn (`onTurnComplete()` + `handler.onDone()`, or flushes the auto-turn buffer).
- Adds tests: multiple steer abort receipts tracked independently; plain interrupt completes the handler without fetching context usage.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (3424 passed, incl. new channel/router cases)
- [x] `npm run build`
- [x] `npm run release:check`
- [x] CHANGELOG.md entry added under `[Unreleased]` → `Fixed`

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] Steered turns keep their live hand-off (priority-'now' successor streaming) unchanged
