### PR TITLE
feat(chat): show send and reply times on chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ version with its date and start a fresh empty `[Unreleased]` above it.
 
 ## [Unreleased]
 
+### Added
+
+- Message timestamps, matching New Qoder: each user bubble shows when it was
+  sent, and each assistant reply shows one time under the whole response next
+  to the completion line. Both reveal on hover so idle conversations stay
+  uncluttered, and replies that were interrupted or errored are timed too.
+
 ### Changed
 
 - The composer permission picker now mirrors New Qoder's three tiers —

--- a/src/core/time/date.ts
+++ b/src/core/time/date.ts
@@ -29,3 +29,23 @@ export function formatDurationMmSs(seconds: number): string {
   }
   return `${mins}m ${secs}s`;
 }
+
+function padTwo(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+/**
+ * Formats a message timestamp as local "YYYY-MM-DD HH:mm".
+ * Returns an empty string for unusable values so callers can skip rendering.
+ */
+export function formatMessageTimestamp(timestamp: number): string {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    return '';
+  }
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const day = `${date.getFullYear()}-${padTwo(date.getMonth() + 1)}-${padTwo(date.getDate())}`;
+  return `${day} ${padTwo(date.getHours())}:${padTwo(date.getMinutes())}`;
+}

--- a/src/features/chat/controllers/input-controller.ts
+++ b/src/features/chat/controllers/input-controller.ts
@@ -6,7 +6,6 @@ import type { BrowserSelectionContext, CanvasSelectionContext } from '../../../c
 import type { EditorSelectionContext } from '../../../core/editor/editor-context';
 import type { ChatRuntime } from '../../../core/runtime/chat-runtime';
 import type { ApprovalCallbackOptions, ChatTurnRequest } from '../../../core/runtime/types';
-import { formatDurationMmSs } from '../../../core/time/date';
 import type { ApprovalDecision, ChatMessage, ExitPlanModeDecision, StreamChunk } from '../../../core/types';
 import {
   type InstructionRefineService,
@@ -447,22 +446,18 @@ export class InputController {
             ? Math.floor((performance.now() - state.responseStartTime) / 1000)
             : 0;
           if (durationSeconds > 0) {
-            const flavorWord =
-              COMPLETION_FLAVOR_WORDS[Math.floor(Math.random() * COMPLETION_FLAVOR_WORDS.length)];
             finalAssistantMsg.durationSeconds = durationSeconds;
-            finalAssistantMsg.durationFlavorWord = flavorWord;
-            // Add footer to live message in DOM
-            if (state.currentContentEl) {
-              const footerEl = state.currentContentEl.createDiv({ cls: 'qoderian-response-footer' });
-              footerEl.createSpan({
-                text: `* ${flavorWord} for ${formatDurationMmSs(durationSeconds)}`,
-                cls: 'qoderian-baked-duration',
-              });
-            }
+            finalAssistantMsg.durationFlavorWord =
+              COMPLETION_FLAVOR_WORDS[Math.floor(Math.random() * COMPLETION_FLAVOR_WORDS.length)];
           }
         } else if (hasError) {
           finalAssistantMsg.durationSeconds = undefined;
           finalAssistantMsg.durationFlavorWord = undefined;
+        }
+
+        // Shared with the stored-message path so live and reloaded turns match.
+        if (state.currentContentEl) {
+          renderer.appendResponseFooter(state.currentContentEl, finalAssistantMsg);
         }
 
         state.currentContentEl = null;

--- a/src/features/chat/rendering/message-renderer.ts
+++ b/src/features/chat/rendering/message-renderer.ts
@@ -3,7 +3,7 @@ import { MarkdownRenderer, Menu, Notice, setIcon } from 'obsidian';
 
 import { hasErrorContentBlock } from '../../../core/chat/error-blocks';
 import type { ChatRewindMode } from '../../../core/runtime/types';
-import { formatDurationMmSs } from '../../../core/time/date';
+import { formatDurationMmSs, formatMessageTimestamp } from '../../../core/time/date';
 import type { ChatMessage, ImageAttachment, SubagentInfo, ToolCallInfo } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type QoderianPlugin from '../../../main';
@@ -142,6 +142,7 @@ export class MessageRenderer {
         const textEl = contentEl.createDiv({ cls: 'qoderian-text-block' });
         void this.renderContent(textEl, textToShow, { userReferenceChips: true });
         this.addUserCopyButton(msgEl, textToShow);
+        this.addUserTimestamp(msgEl, msg.timestamp);
         this.applyTocTitle(msgEl, textToShow);
       }
       if (this.rewindCallback || this.forkCallback) {
@@ -187,6 +188,7 @@ export class MessageRenderer {
 
     if (textToShow) {
       this.addUserCopyButton(msgEl, textToShow);
+      this.addUserTimestamp(msgEl, msg.timestamp);
     }
   }
 
@@ -277,6 +279,7 @@ export class MessageRenderer {
         const textEl = contentEl.createDiv({ cls: 'qoderian-text-block' });
         void this.renderContent(textEl, textToShow, { userReferenceChips: true });
         this.addUserCopyButton(msgEl, textToShow);
+        this.addUserTimestamp(msgEl, msg.timestamp);
         this.applyTocTitle(msgEl, textToShow);
       }
       if (msg.userMessageId) {
@@ -345,7 +348,11 @@ export class MessageRenderer {
   /**
    * Renders assistant message content (content blocks or fallback).
    */
-  private renderAssistantContent(msg: ChatMessage, contentEl: HTMLElement): void {
+  private renderAssistantContent(
+    msg: ChatMessage,
+    contentEl: HTMLElement,
+    includeFooter = true,
+  ): void {
     if (msg.contentBlocks && msg.contentBlocks.length > 0) {
       const renderedToolIds = new Set<string>();
       for (const block of msg.contentBlocks) {
@@ -413,27 +420,47 @@ export class MessageRenderer {
       }
     }
 
-    // Failed turns do not get a normal-completion flavor footer.
+    if (includeFooter) {
+      this.appendResponseFooter(contentEl, msg);
+    }
+  }
+
+  /**
+   * Renders the footer under a whole assistant reply: the completion flavor
+   * line when the turn finished normally, plus the reply's timestamp.
+   * Shared with the streaming path so both renders stay identical.
+   */
+  appendResponseFooter(contentEl: HTMLElement, msg: ChatMessage): void {
+    const timeText = formatMessageTimestamp(msg.timestamp);
+    // Failed turns do not get a normal-completion flavor line.
     const hasCompactBoundary = msg.contentBlocks?.some(b => b.type === 'context_compacted');
-    if (
+    const showDuration = Boolean(
       msg.durationSeconds
       && msg.durationSeconds > 0
       && !hasCompactBoundary
       && !hasErrorContentBlock(msg)
-    ) {
+    );
+    if (!timeText && !showDuration) {
+      return;
+    }
+
+    const footerEl = contentEl.createDiv({ cls: 'qoderian-response-footer' });
+    if (showDuration) {
       const flavorWord = msg.durationFlavorWord || 'Baked';
-      const footerEl = contentEl.createDiv({ cls: 'qoderian-response-footer' });
       footerEl.createSpan({
-        text: `* ${flavorWord} for ${formatDurationMmSs(msg.durationSeconds)}`,
+        text: `* ${flavorWord} for ${formatDurationMmSs(msg.durationSeconds as number)}`,
         cls: 'qoderian-baked-duration',
       });
+    }
+    if (timeText) {
+      footerEl.createSpan({ cls: 'qoderian-message-time', text: timeText });
     }
   }
 
   /** Rebuilds the active assistant content after a streamed block is upgraded. */
   rerenderAssistantContent(msg: ChatMessage, contentEl: HTMLElement): void {
     contentEl.empty();
-    this.renderAssistantContent(msg, contentEl);
+    this.renderAssistantContent(msg, contentEl, false);
   }
 
   /**
@@ -826,6 +853,22 @@ export class MessageRenderer {
     const existing = msgEl.querySelector<HTMLElement>('.qoderian-user-msg-actions');
     if (existing) return existing;
     return msgEl.createDiv({ cls: 'qoderian-user-msg-actions' });
+  }
+
+  /**
+   * Shows when the message was sent. Rewind/fork buttons prepend themselves to
+   * the toolbar, so the leading position is pinned in CSS rather than by DOM order.
+   */
+  private addUserTimestamp(msgEl: HTMLElement, timestamp: number): void {
+    const timeText = formatMessageTimestamp(timestamp);
+    if (!timeText) return;
+    const toolbar = this.getOrCreateActionsToolbar(msgEl);
+    const existing = toolbar.querySelector<HTMLElement>('.qoderian-message-time');
+    if (existing) {
+      existing.setText(timeText);
+      return;
+    }
+    toolbar.createSpan({ cls: 'qoderian-message-time', text: timeText });
   }
 
   private addUserCopyButton(msgEl: HTMLElement, content: string): void {

--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -209,8 +209,12 @@
   background: var(--background-modifier-border-hover);
 }
 
-/* Response duration footer - styled as another line of content */
+/* Response footer - the completion line plus the reply timestamp, on one line */
 .qoderian-response-footer {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
   margin-top: 8px;
 }
 
@@ -221,12 +225,31 @@
   font-style: italic;
 }
 
+/* Message timestamp, shared by user bubbles and assistant replies */
+.qoderian-message-time {
+  color: var(--text-faint);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+/* Revealed on hover like the user bubble's. Toggled via opacity so the
+   duration line beside it never shifts. */
+.qoderian-response-footer .qoderian-message-time {
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.qoderian-message-assistant:hover .qoderian-response-footer .qoderian-message-time {
+  opacity: 1;
+}
+
 /* Action buttons toolbar below user messages */
 .qoderian-user-msg-actions {
   position: absolute;
   bottom: -20px;
   right: 0;
   display: flex;
+  align-items: center;
   gap: 12px;
   opacity: 0;
   transition: opacity 0.15s;
@@ -246,6 +269,12 @@
   transition: color 0.15s;
 }
 
+/* Rewind/fork buttons prepend themselves, so pin the time ahead of them here. */
+.qoderian-user-msg-actions .qoderian-message-time {
+  order: -1;
+  cursor: default;
+}
+
 .qoderian-user-msg-actions span svg {
   width: 16px;
   height: 16px;
@@ -253,6 +282,10 @@
 
 .qoderian-user-msg-actions span:hover {
   color: var(--text-normal);
+}
+
+.qoderian-user-msg-actions .qoderian-message-time:hover {
+  color: var(--text-faint);
 }
 
 .qoderian-user-msg-actions span.copied {

--- a/tests/unit/core/time/date.test.ts
+++ b/tests/unit/core/time/date.test.ts
@@ -1,4 +1,8 @@
-import { formatDurationMmSs, getTodayDate } from '../../../../src/core/time/date';
+import {
+  formatDurationMmSs,
+  formatMessageTimestamp,
+  getTodayDate,
+} from '../../../../src/core/time/date';
 
 describe('getTodayDate', () => {
   it('returns readable date with ISO suffix', () => {
@@ -76,5 +80,24 @@ describe('formatDurationMmSs', () => {
       expect(formatDurationMmSs(Infinity)).toBe('0s');
       expect(formatDurationMmSs(-Infinity)).toBe('0s');
     });
+  });
+});
+
+describe('formatMessageTimestamp', () => {
+  it('formats a timestamp as local YYYY-MM-DD HH:mm', () => {
+    const local = new Date(2026, 7, 29, 17, 50).getTime();
+    expect(formatMessageTimestamp(local)).toBe('2026-08-29 17:50');
+  });
+
+  it('pads month, day, hour and minute', () => {
+    const local = new Date(2026, 0, 5, 9, 7).getTime();
+    expect(formatMessageTimestamp(local)).toBe('2026-01-05 09:07');
+  });
+
+  it('returns an empty string for unusable values so callers skip rendering', () => {
+    expect(formatMessageTimestamp(0)).toBe('');
+    expect(formatMessageTimestamp(-1)).toBe('');
+    expect(formatMessageTimestamp(NaN)).toBe('');
+    expect(formatMessageTimestamp(Infinity)).toBe('');
   });
 });

--- a/tests/unit/features/chat/rendering/message-renderer.error.test.ts
+++ b/tests/unit/features/chat/rendering/message-renderer.error.test.ts
@@ -3,24 +3,24 @@ import { createMockEl } from '@test/helpers/mock-element';
 import type { ChatMessage } from '@/core/types';
 import { MessageRenderer } from '@/features/chat/rendering/message-renderer';
 
+function createRenderer(messagesEl: ReturnType<typeof createMockEl>): MessageRenderer {
+  const plugin = {
+    app: {},
+    settings: { expandFileEditsByDefault: false, mediaFolder: '' },
+  };
+  const component = { registerDomEvent: jest.fn() };
+  return new MessageRenderer(plugin as any, component as any, messagesEl);
+}
+
 describe('MessageRenderer error blocks', () => {
-  it('renders a formal error block without a normal-completion duration footer', () => {
+  it('renders a formal error block without a normal-completion duration line', () => {
     const messagesEl = createMockEl();
-    const plugin = {
-      app: {},
-      settings: { expandFileEditsByDefault: false, mediaFolder: '' },
-    };
-    const component = { registerDomEvent: jest.fn() };
-    const renderer = new MessageRenderer(
-      plugin as any,
-      component as any,
-      messagesEl,
-    );
+    const renderer = createRenderer(messagesEl);
     const message: ChatMessage = {
       id: 'assistant-error',
       role: 'assistant',
       content: '',
-      timestamp: 1,
+      timestamp: new Date('2026-08-29T17:50:00').getTime(),
       durationSeconds: 4,
       durationFlavorWord: 'Distilled',
       contentBlocks: [{ type: 'error', content: 'Credit limit reached.' }],
@@ -29,6 +29,9 @@ describe('MessageRenderer error blocks', () => {
     renderer.renderStoredMessage(message);
 
     expect(messagesEl.querySelector('.qoderian-error-block')).not.toBeNull();
-    expect(messagesEl.querySelector('.qoderian-response-footer')).toBeNull();
+    expect(messagesEl.querySelector('.qoderian-baked-duration')).toBeNull();
+    // The footer survives so a failed turn still reports when it happened.
+    expect(messagesEl.querySelector('.qoderian-message-time')?.textContent)
+      .toBe('2026-08-29 17:50');
   });
 });

--- a/tests/unit/features/chat/rendering/message-renderer.timestamps.test.ts
+++ b/tests/unit/features/chat/rendering/message-renderer.timestamps.test.ts
@@ -1,0 +1,106 @@
+import { createMockEl } from '@test/helpers/mock-element';
+
+import type { ChatMessage } from '@/core/types';
+import { MessageRenderer } from '@/features/chat/rendering/message-renderer';
+
+function createRenderer() {
+  const messagesEl = createMockEl();
+  const component = { registerDomEvent: jest.fn() };
+  const plugin = {
+    app: {},
+    settings: { expandFileEditsByDefault: false, mediaFolder: '' },
+  };
+  return {
+    messagesEl,
+    renderer: new MessageRenderer(plugin as any, component as any, messagesEl),
+  };
+}
+
+const SENT_AT = new Date(2026, 7, 29, 17, 50).getTime();
+
+function userMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: 'hello',
+    timestamp: SENT_AT,
+    ...overrides,
+  };
+}
+
+function assistantMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: '',
+    timestamp: SENT_AT,
+    contentBlocks: [{ type: 'text', content: 'sure' }],
+    ...overrides,
+  };
+}
+
+describe('MessageRenderer timestamps', () => {
+  it('shows the send time in the user action toolbar', () => {
+    const { messagesEl, renderer } = createRenderer();
+
+    renderer.renderStoredMessage(userMessage());
+
+    const toolbar = messagesEl.querySelector('.qoderian-user-msg-actions');
+    expect(toolbar).not.toBeNull();
+    expect(toolbar?.querySelector('.qoderian-message-time')?.textContent)
+      .toBe('2026-08-29 17:50');
+  });
+
+  it('shows the send time on live user messages too', () => {
+    const { messagesEl, renderer } = createRenderer();
+
+    renderer.addMessage(userMessage({ id: 'user-live' }));
+
+    expect(messagesEl.querySelector('.qoderian-message-time')?.textContent)
+      .toBe('2026-08-29 17:50');
+  });
+
+  it('shows one reply time under the whole assistant message, beside the duration', () => {
+    const { messagesEl, renderer } = createRenderer();
+
+    renderer.renderStoredMessage(assistantMessage({
+      durationSeconds: 16,
+      durationFlavorWord: 'Conjured',
+    }));
+
+    const footer = messagesEl.querySelector('.qoderian-response-footer');
+    expect(footer).not.toBeNull();
+    expect(messagesEl.querySelectorAll('.qoderian-message-time').length).toBe(1);
+    expect(messagesEl.querySelector('.qoderian-baked-duration')?.textContent)
+      .toBe('* Conjured for 16s');
+    expect(messagesEl.querySelector('.qoderian-message-time')?.textContent)
+      .toBe('2026-08-29 17:50');
+  });
+
+  it('still times an interrupted reply that has no duration line', () => {
+    const { messagesEl, renderer } = createRenderer();
+
+    renderer.renderStoredMessage(assistantMessage({ isInterrupt: true }));
+
+    expect(messagesEl.querySelector('.qoderian-baked-duration')).toBeNull();
+    expect(messagesEl.querySelector('.qoderian-message-time')?.textContent)
+      .toBe('2026-08-29 17:50');
+  });
+
+  it('omits the footer entirely when the timestamp is unusable', () => {
+    const { messagesEl, renderer } = createRenderer();
+
+    renderer.renderStoredMessage(assistantMessage({ timestamp: 0 }));
+
+    expect(messagesEl.querySelector('.qoderian-response-footer')).toBeNull();
+  });
+
+  it('keeps the footer off the active reply while it is still streaming', () => {
+    const { renderer } = createRenderer();
+    const contentEl = createMockEl();
+
+    renderer.rerenderAssistantContent(assistantMessage(), contentEl);
+
+    expect(contentEl.querySelector('.qoderian-response-footer')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Show a send time under every user bubble and one reply time under every assistant response, matching New Qoder. Both reveal on hover, toggled with `opacity` so neither the bubble nor the completion line shifts.
- No new data was needed: `ChatMessage.timestamp` is already populated for live turns and parsed from the CLI session file on reload, so restored conversations are timed as accurately as fresh ones. New `formatMessageTimestamp` renders it as local `YYYY-MM-DD HH:mm` and returns an empty string for unusable values so callers skip rendering.
- The user time lives in the existing hover toolbar, pinned ahead of the fork/rewind/copy icons via CSS `order` — those buttons prepend themselves with `insertBefore(firstChild)`, so DOM order alone would not hold the position.
- The assistant footer is now always built instead of only on normally completed turns, so interrupted, errored and compacted replies are timed too. Extracted `appendResponseFooter()` and pointed the streaming path at it, replacing the duplicate markup that `input-controller` was assembling itself; mid-stream re-renders skip the footer so the time never appears before the turn ends.

Why: conversations carried no timestamps at all, so there was no way to tell when a message was sent or when a reply came back.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 153 suites / 3436 tests pass, including 10 new cases: 4 for the formatter's padding and rejected inputs, and 6 rendering cases (live and stored user bubbles, one reply time beside the duration on a single row, interrupted replies still timed, no footer when the timestamp is unusable, no footer mid-stream)
- [x] `npm run build`
- [x] `npm run release:check`
- [x] `npm run audit:prod` — 0 vulnerabilities
- [x] Tested affected qodercli behavior against a real CLI when applicable — deployed into a local vault and driven through the Obsidian renderer over CDP. A restored conversation timed 2/2 user bubbles (toolbar `opacity: 0` at rest, time at `order: -1`) and 2/2 reply footers. Ran one real turn: the footer rendered `["qoderian-baked-duration", "qoderian-message-time"]` as `* Crafted for 6s` + `2026-08-30 11:10` with `sameRow: true`. Hovering an assistant reply moved the time's computed opacity `0 → 1 → 0` while the footer height stayed 17px, confirming no layout shift.

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible changes are documented in `CHANGELOG.md`