### PR TITLE
fix(chat): stop live composer overflowing the input box on large pastes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ version with its date and start a fresh empty `[Unreleased]` above it.
   non-interactive mode.` This also covers commands not yet filtered out of
   the popover.
 
+- Pasting a large block of text into the composer painted it outside the
+  input box, spilling over the toolbar and past the bottom of the sidebar.
+  The input box now grows with the pasted text up to its usual height cap,
+  scrolls internally beyond that, and shrinks back when the text is cleared.
+
 ## [1.0.6] - 2026-08-27
 
 ### Added

--- a/src/style/components/composer.css
+++ b/src/style/components/composer.css
@@ -6,10 +6,13 @@
   display: none;
 }
 
+/* No min-height override here: the host must keep the flex content-based
+   minimum so the editor's min/max-height bounds propagate to the wrapper.
+   min-height: 0 collapsed the host to the wrapper's base height and let the
+   editor paint outside the input box on large pastes. */
 .qoderian-input-wrapper .qoderian-live-composer-host {
   display: flex;
   flex: 1 1 0;
-  min-height: 0;
   min-width: 0;
 }
 


### PR DESCRIPTION
## Summary

- **What changed?** Dropped the `min-height: 0` override on
  `.qoderian-live-composer-host` in `src/style/components/composer.css`, plus a
  CHANGELOG entry.
- **Why is it needed?** The host is a `flex: 1 1 0` item, so `min-height: 0`
  disabled its automatic (content-based) minimum size. The CodeMirror editor's
  height then could not propagate up to the bordered wrapper, which stayed
  pinned at its 140px baseline while the editor grew — so a large paste painted
  the text outside the input box, over the toolbar and past the bottom of the
  sidebar. Removing the override restores the content-based minimum, matching
  how the legacy textarea behaved. `min-width: 0` is kept, so horizontal
  shrinking in narrow sidebars is unaffected.

### Measured before / after

Verified in a real Obsidian vault by driving the renderer over CDP and reading
`getBoundingClientRect()` deltas, pasting 200 lines (~10.9k chars):

| | before | after |
|---|---|---|
| wrapper height | 140px (never grew) | 626px |
| host height | 70px (never grew) | 556px |
| editor bottom vs wrapper bottom | **+447px (overflowing)** | −39px (inside) |
| editor bottom vs toolbar top | **+486px (covering it)** | 0px |

Grow/shrink cycle holds with no drift: 140 → 166 (4 lines) → 626 (200 lines) →
140 (cleared) → 626 (regrown) → 140. In a 260px-wide sidebar the editor stays
inside both vertically (−65px) and horizontally (−1px).

Note: the `minHeight` that `LiveComposer.updateHeight()` computes turned out not
to participate in layout on the CodeMirror path — the computed `min-height`
stayed at 60px throughout, since the editor's own height tracks its content and
is capped by `max-height`. That calculation is effectively inert here; left
untouched in this PR to keep it to the fix.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (155 suites, 3447 tests)
- [x] `npm run build`
- [x] `npm run release:check`
- [x] `npm run audit:prod` (0 vulnerabilities)
- [x] Tested affected qodercli behavior against a real CLI when applicable —
      no CLI surface is touched; validated end-to-end in a real Obsidian vault
      instead, with before/after geometry captured above.

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible changes are documented in `CHANGELOG.md`