### PR TITLE
refactor(chat): drop the inert min-height calculation from the live composer

### DIFF
--- a/src/features/chat/ui/composer/live-composer.ts
+++ b/src/features/chat/ui/composer/live-composer.ts
@@ -13,11 +13,7 @@ import {
 } from '@codemirror/view';
 import { setIcon } from 'obsidian';
 
-import {
-  calculateTextareaMaxHeight,
-  calculateTextareaMinHeight,
-  TEXTAREA_BASE_MIN_HEIGHT,
-} from '../textarea-resize';
+import { calculateTextareaMaxHeight } from '../textarea-resize';
 import {
   type ComposerReference,
   type ComposerReferenceRange,
@@ -273,27 +269,16 @@ export class LiveComposer {
   }
 
   /**
-   * Mirrors the textarea auto-resize contract: grows with content, capped at
-   * a share of the view height. Metrics come from the CodeMirror scroller.
+   * Caps the editor at a share of the view height. The editor's own height
+   * tracks its content and the host's content-based flex minimum propagates
+   * it to the wrapper, so only the cap needs writing here.
    */
   private updateHeight(): void {
     const viewHeight = this.view.dom.closest('.qoderian-container')?.clientHeight
       ?? this.view.dom.ownerDocument.defaultView?.innerHeight
       ?? 0;
-    const maxHeight = calculateTextareaMaxHeight(viewHeight);
-
-    const scroller = this.view.dom.querySelector<HTMLElement>('.cm-scroller');
-    const contentHeight = scroller
-      ? Math.min(scroller.scrollHeight, maxHeight)
-      : TEXTAREA_BASE_MIN_HEIGHT;
-    const minHeight = calculateTextareaMinHeight({
-      contentHeight,
-      flexAllocatedHeight: this.view.dom.offsetHeight,
-    });
-
     this.view.dom.setCssProps({
-      '--qoderian-textarea-min-height': `${minHeight}px`,
-      '--qoderian-textarea-max-height': `${maxHeight}px`,
+      '--qoderian-textarea-max-height': `${calculateTextareaMaxHeight(viewHeight)}px`,
     });
   }
 }

--- a/src/style/components/composer.css
+++ b/src/style/components/composer.css
@@ -20,7 +20,7 @@
    height bounds) so the wrapper layout stays identical. */
 .qoderian-input-wrapper .qoderian-live-composer.cm-editor {
   flex: 1 1 auto;
-  min-height: var(--qoderian-textarea-min-height, 60px);
+  min-height: 60px;
   max-height: var(--qoderian-textarea-max-height, none);
   background: transparent;
   color: var(--text-normal);


### PR DESCRIPTION
## Summary

- **What changed?** Removed the `minHeight` computation and its CSS variable
  write from `LiveComposer.updateHeight()`, and pinned the editor's
  `min-height` to the `60px` constant the variable always fell back to.
- **Why is it needed?** End-to-end measurement (CDP-driven real Obsidian,
  geometry readouts across grow/shrink cycles) showed the computed
  `min-height` stayed at 60px in every observed state on the CodeMirror
  path: the editor's height tracks its content and is capped by
  `max-height`, while the host's content-based flex minimum (restored in
  #47) propagates growth to the wrapper. The calculation was inert — dead
  code left over from mirroring the legacy textarea contract. The textarea
  path (`autoResizeTextarea`) keeps its own resize logic untouched.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (155 suites, 3447 tests)
- [x] `npm run build`
- [ ] `npm run release:check`
- [ ] `npm run audit:prod`
- [x] Tested affected qodercli behavior against a real CLI when applicable —
      no CLI surface touched; behavior parity established by the #47
      end-to-end measurement (computed min-height was 60px in all states,
      which is exactly the constant now pinned in CSS).

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible changes are documented in `CHANGELOG.md` — no user-visible
      change; pure dead-code removal, no CHANGELOG entry needed.