### PR TITLE
perf: speed up startup loading with many sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ version with its date and start a fresh empty `[Unreleased]` above it.
 
 ### Changed
 
+- Startup with many saved sessions is now much faster: session metadata is
+  read in parallel and legacy edition history files are probed once per
+  startup instead of repeatedly blocking the interface, so vaults with
+  hundreds of sessions no longer stall while Qoderian loads.
+
 - The composer permission picker now mirrors New Qoder's three tiers —
   Ask approval, Auto approval, and Full access — and its labels and
   descriptions are localized across all ten supported locales instead of

--- a/scripts/generate-session-fixture.mjs
+++ b/scripts/generate-session-fixture.mjs
@@ -116,13 +116,12 @@ removed += removeFixtures(projectsDir(otherEdition, vault), '.jsonl');
 fs.mkdirSync(metaDir, { recursive: true });
 fs.mkdirSync(projectsDir(args.edition, vault), { recursive: true });
 
-const randomSuffix = () => Math.random().toString(16).slice(2, 10);
 let stampedCount = 0;
 let legacyWithFileCount = 0;
 let missingCount = 0;
 
 for (let index = 0; index < args.total; index += 1) {
-  const id = `${FIXTURE_PREFIX}${index}-${randomSuffix()}`;
+  const id = `${FIXTURE_PREFIX}${index}`;
   const isLegacy = index >= args.total - args.legacy;
   const isMissing = isLegacy && index >= args.total - args.missing;
 

--- a/scripts/generate-session-fixture.mjs
+++ b/scripts/generate-session-fixture.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Generates synthetic Qoderian session data for load-performance measurement.
+ *
+ * Writes fixture metadata into `<vault>/.qoderian/sessions/` and (for the
+ * legacy sessions that should resolve to a history file) a one-line JSONL
+ * under the edition's SDK projects directory. Every generated name carries
+ * the `fixture-` prefix, so re-running the script first removes only files
+ * created by previous runs — real sessions in the vault are never touched.
+ *
+ * Usage:
+ *   node scripts/generate-session-fixture.mjs --vault /path/to/vault \
+ *     [--total 300] [--legacy 100] [--missing 50] [--edition global]
+ *
+ *   --total    total sessions to generate (default 300)
+ *   --legacy   sessions without an `edition` stamp (default total/3)
+ *   --missing  legacy sessions with no history file anywhere (default legacy/2)
+ *   --edition  edition used for stamps and history placement: global|cn
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const FIXTURE_PREFIX = 'fixture-';
+const HOME_DIRS = { global: '.qoder', cn: '.qoder-cn' };
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { vault: null, total: 300, legacy: null, missing: null, edition: 'global' };
+  for (let i = 0; i < argv.length; i += 1) {
+    switch (argv[i]) {
+      case '--vault': args.vault = argv[++i]; break;
+      case '--total': args.total = Number(argv[++i]); break;
+      case '--legacy': args.legacy = Number(argv[++i]); break;
+      case '--missing': args.missing = Number(argv[++i]); break;
+      case '--edition': args.edition = argv[++i]; break;
+      default: fail(`Unknown argument: ${argv[i]}`);
+    }
+  }
+  if (!args.vault) fail('--vault <path> is required');
+  if (!HOME_DIRS[args.edition]) fail('--edition must be global or cn');
+  if (!Number.isInteger(args.total) || args.total < 0) fail('--total must be a non-negative integer');
+  args.legacy ??= Math.floor(args.total / 3);
+  args.missing ??= Math.floor(args.legacy / 2);
+  if (args.legacy < 0 || args.legacy > args.total) fail('--legacy must be within [0, total]');
+  if (args.missing < 0 || args.missing > args.legacy) fail('--missing must be within [0, legacy]');
+  return args;
+}
+
+// Mirrors encodeVaultPathForSDK in src/qoder/history/sdk-session-paths.ts.
+function encodeVaultPath(vaultPath) {
+  return path.resolve(vaultPath).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+function sessionsDir(vault) {
+  return path.join(vault, '.qoderian', 'sessions');
+}
+
+function projectsDir(edition, vault) {
+  return path.join(os.homedir(), HOME_DIRS[edition], 'projects', encodeVaultPath(vault));
+}
+
+function removeFixtures(dir, suffix) {
+  if (!fs.existsSync(dir)) return 0;
+  let removed = 0;
+  for (const entry of fs.readdirSync(dir)) {
+    if (entry.startsWith(FIXTURE_PREFIX) && entry.endsWith(suffix)) {
+      fs.rmSync(path.join(dir, entry));
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+function makeMetadata(id, stamp, edition, index) {
+  const timestamp = Date.now() - index * 60_000;
+  const metadata = {
+    id,
+    title: `Fixture session ${index}`,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    lastResponseAt: timestamp,
+    sessionId: id,
+  };
+  if (stamp) {
+    metadata.edition = edition;
+  }
+  return metadata;
+}
+
+function makeHistoryLine(id) {
+  const message = {
+    type: 'user',
+    uuid: `${id}-line-1`,
+    timestamp: new Date().toISOString(),
+    message: { role: 'user', content: 'fixture session' },
+  };
+  return `${JSON.stringify(message)}\n`;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const vault = path.resolve(args.vault);
+if (!fs.existsSync(vault)) fail(`Vault path does not exist: ${vault}`);
+
+const metaDir = sessionsDir(vault);
+const otherEdition = args.edition === 'global' ? 'cn' : 'global';
+
+let removed = removeFixtures(metaDir, '.meta.json');
+removed += removeFixtures(projectsDir(args.edition, vault), '.jsonl');
+removed += removeFixtures(projectsDir(otherEdition, vault), '.jsonl');
+
+fs.mkdirSync(metaDir, { recursive: true });
+fs.mkdirSync(projectsDir(args.edition, vault), { recursive: true });
+
+const randomSuffix = () => Math.random().toString(16).slice(2, 10);
+let stampedCount = 0;
+let legacyWithFileCount = 0;
+let missingCount = 0;
+
+for (let index = 0; index < args.total; index += 1) {
+  const id = `${FIXTURE_PREFIX}${index}-${randomSuffix()}`;
+  const isLegacy = index >= args.total - args.legacy;
+  const isMissing = isLegacy && index >= args.total - args.missing;
+
+  fs.writeFileSync(
+    path.join(metaDir, `${id}.meta.json`),
+    JSON.stringify(makeMetadata(id, !isLegacy, args.edition, index), null, 2),
+  );
+
+  if (isLegacy && !isMissing) {
+    fs.writeFileSync(path.join(projectsDir(args.edition, vault), `${id}.jsonl`), makeHistoryLine(id));
+    legacyWithFileCount += 1;
+  } else if (isMissing) {
+    missingCount += 1;
+  } else {
+    stampedCount += 1;
+  }
+}
+
+console.log(`Vault: ${vault}`);
+console.log(`Removed ${removed} fixture file(s) from previous runs.`);
+console.log(`Generated ${args.total} session(s): ${stampedCount} stamped (${args.edition}), `
+  + `${legacyWithFileCount} legacy with history, ${missingCount} legacy missing.`);

--- a/src/app/storage/session-storage.ts
+++ b/src/app/storage/session-storage.ts
@@ -1,9 +1,13 @@
+import { mapWithConcurrency } from '../../core/async/map-with-concurrency';
 import { reportRestoreIssue } from '../../core/diagnostics/restore-report';
 import type { VaultFileAdapter } from '../../core/storage/vault-file-adapter';
 import type { SessionMetadata } from '../../core/types';
 import { SESSIONS_PATH } from './storage-paths';
 
 export { SESSIONS_PATH };
+
+/** Bounds in-flight metadata file reads during startup listing. */
+const METADATA_READ_CONCURRENCY = 8;
 
 export class SessionStorage {
   constructor(private adapter: VaultFileAdapter) {}
@@ -33,19 +37,24 @@ export class SessionStorage {
   }
 
   async listMetadata(): Promise<SessionMetadata[]> {
-    const metas: SessionMetadata[] = [];
+    const filePaths = await this.listMetadataFiles();
 
-    for (const filePath of await this.listMetadataFiles()) {
-      try {
-        const content = await this.adapter.read(filePath);
-        metas.push(JSON.parse(content) as SessionMetadata);
-      } catch (error) {
-        // Skip files that fail to load, but surface the skip.
-        reportRestoreIssue('metadata', `Failed to read session metadata file "${filePath}": ${errorMessage(error)}`);
-      }
-    }
+    const metas = await mapWithConcurrency(
+      filePaths,
+      METADATA_READ_CONCURRENCY,
+      async (filePath): Promise<SessionMetadata | null> => {
+        try {
+          const content = await this.adapter.read(filePath);
+          return JSON.parse(content) as SessionMetadata;
+        } catch (error) {
+          // Skip files that fail to load, but surface the skip.
+          reportRestoreIssue('metadata', `Failed to read session metadata file "${filePath}": ${errorMessage(error)}`);
+          return null;
+        }
+      },
+    );
 
-    return metas;
+    return metas.filter((meta): meta is SessionMetadata => meta !== null);
   }
 
   private async listMetadataFiles(): Promise<string[]> {

--- a/src/core/async/map-with-concurrency.ts
+++ b/src/core/async/map-with-concurrency.ts
@@ -1,0 +1,33 @@
+/**
+ * Maps items with a capped number of in-flight async operations.
+ *
+ * Unlike fixed-chunk `Promise.all` batching, a worker that finishes picks up
+ * the next item immediately, so one slow task cannot hold up a whole batch.
+ * Output order always matches input order. Failures are the mapper's concern:
+ * wrap the per-item work in try/catch and return a sentinel if skips are
+ * acceptable, since a thrown error rejects the whole call.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const current = nextIndex;
+      nextIndex += 1;
+      results[current] = await mapper(items[current], current);
+    }
+  }
+
+  const workerCount = Math.max(0, Math.min(limit, items.length));
+  const workers: Promise<void>[] = [];
+  for (let worker = 0; worker < workerCount; worker += 1) {
+    workers.push(runWorker());
+  }
+  await Promise.all(workers);
+  return results;
+}

--- a/src/core/diagnostics/performance.ts
+++ b/src/core/diagnostics/performance.ts
@@ -1,0 +1,19 @@
+/**
+ * Load-path timing diagnostics.
+ *
+ * Startup work (session metadata reads, edition migration, index building,
+ * tab restore, history hydration) grows with the number of stored sessions,
+ * and regressions were invisible until the plugin felt slow. Each stage wraps
+ * itself in `measureAsync` and logs its elapsed time; labels are stable phase
+ * names without user data, so the lines are safe to share in bug reports.
+ */
+
+export async function measureAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    return await fn();
+  } finally {
+    const elapsedMs = Math.round((performance.now() - startedAt) * 10) / 10;
+    console.info(`[qoderian perf] ${label}: ${elapsedMs}ms`);
+  }
+}

--- a/src/features/chat/tabs/tab-manager.ts
+++ b/src/features/chat/tabs/tab-manager.ts
@@ -1,5 +1,6 @@
 import { Notice } from 'obsidian';
 
+import { measureAsync } from '../../../core/diagnostics/performance';
 import { reportRestoreIssue } from '../../../core/diagnostics/restore-report';
 import type { ChatRuntime } from '../../../core/runtime/chat-runtime';
 import { t } from '../../../i18n/i18n';
@@ -529,6 +530,10 @@ export class TabManager implements TabManagerInterface {
 
   /** Restores state from persisted data. */
   async restoreState(state: PersistedTabManagerState): Promise<void> {
+    await measureAsync('startup.restoreTabs', () => this.restoreStateInner(state));
+  }
+
+  private async restoreStateInner(state: PersistedTabManagerState): Promise<void> {
     this.isRestoringState = true;
     try {
       // Create tabs from persisted state with error handling.

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,8 +29,8 @@ import type { Locale } from './i18n/types';
 import { getActiveQoderCliEdition, setActiveQoderCliEdition } from './qoder/config/cli-edition';
 import { normalizeQoderSettings } from './qoder/config/qoder-settings-reconciler';
 import { getQoderSettings } from './qoder/config/settings';
-import { sdkSessionExistsForEdition } from './qoder/history/sdk-session-paths';
-import { resolveLegacySessionEdition, selectMetadataForEdition } from './qoder/history/session-edition-filter';
+import { resolveLegacySessionEdition, selectMetadataForEdition, type SessionEditionLocation } from './qoder/history/session-edition-filter';
+import { probeLegacySessionLocations, SessionEditionProbe } from './qoder/history/session-edition-probe';
 import { extractUserDisplayContent } from './qoder/prompt/context/prompt-context';
 import {
   createQoderServices,
@@ -422,13 +422,17 @@ export default class QoderianPlugin extends Plugin {
       'startup.listMetadata',
       () => this.storage.sessions.listMetadata(),
     );
+    const legacyLocations = await measureAsync(
+      'startup.probeLegacyEditions',
+      () => this.probeLegacyEditionLocations(allMetadata),
+    );
     await measureAsync(
       'startup.migrateLegacyEditions',
-      () => this.migrateLegacySessionEditions(allMetadata),
+      () => this.migrateLegacySessionEditions(allMetadata, legacyLocations),
     );
     this.conversations = await measureAsync(
       'startup.buildConversationIndex',
-      () => this.buildConversationIndex(allMetadata),
+      () => this.buildConversationIndex(allMetadata, legacyLocations),
     );
     setLocale(this.settings.locale as Locale);
 
@@ -453,17 +457,18 @@ export default class QoderianPlugin extends Plugin {
 
   /**
    * Builds the in-memory conversation index from session metadata, keeping
-   * only the sessions owned by the active CLI edition.
+   * only the sessions owned by the active CLI edition. Legacy locations come
+   * from the transaction's probe so no filesystem access happens here.
    */
-  private async buildConversationIndex(allMetadata: SessionMetadata[]): Promise<Conversation[]> {
+  private async buildConversationIndex(
+    allMetadata: SessionMetadata[],
+    legacyLocations: Map<string, SessionEditionLocation>,
+  ): Promise<Conversation[]> {
     const edition = getActiveQoderCliEdition();
-    const otherEdition = edition === 'cn' ? 'global' : 'cn';
-    const vaultPath = getVaultPath(this.app);
     const visible = selectMetadataForEdition(
       allMetadata,
       edition,
-      (sessionId) => vaultPath !== null
-        && sdkSessionExistsForEdition(vaultPath, sessionId, otherEdition),
+      sessionId => (legacyLocations.get(sessionId) ?? 'unknown') === 'other',
     );
 
     return visible.map(meta => {
@@ -494,7 +499,24 @@ export default class QoderianPlugin extends Plugin {
   /** Rebuilds the conversation index after the CLI edition changes. */
   async reloadConversationIndex(): Promise<void> {
     const allMetadata = await this.storage.sessions.listMetadata();
-    this.conversations = await this.buildConversationIndex(allMetadata);
+    const legacyLocations = await this.probeLegacyEditionLocations(allMetadata);
+    this.conversations = await this.buildConversationIndex(allMetadata, legacyLocations);
+  }
+
+  /**
+   * Probes legacy session history files once per load transaction; the
+   * resulting locations are shared by the migration and index stages so each
+   * file is accessed at most once.
+   */
+  private async probeLegacyEditionLocations(
+    allMetadata: SessionMetadata[],
+  ): Promise<Map<string, SessionEditionLocation>> {
+    const vaultPath = getVaultPath(this.app);
+    if (vaultPath === null) {
+      return new Map();
+    }
+    const probe = new SessionEditionProbe(vaultPath);
+    return probeLegacySessionLocations(allMetadata, getActiveQoderCliEdition(), probe);
   }
 
   /**
@@ -503,26 +525,21 @@ export default class QoderianPlugin extends Plugin {
    * history file, so future loads no longer depend on filesystem probing.
    * Sessions whose files are missing everywhere stay unstamped.
    */
-  private async migrateLegacySessionEditions(allMetadata: SessionMetadata[]): Promise<void> {
+  private async migrateLegacySessionEditions(
+    allMetadata: SessionMetadata[],
+    legacyLocations: Map<string, SessionEditionLocation>,
+  ): Promise<void> {
     const edition = getActiveQoderCliEdition();
-    const otherEdition = edition === 'cn' ? 'global' : 'cn';
-    const vaultPath = getVaultPath(this.app);
-    if (vaultPath === null) {
-      return;
-    }
 
     for (const meta of allMetadata) {
       if (meta.edition !== undefined) {
         continue;
       }
-      const resolved = resolveLegacySessionEdition(meta, edition, (sessionId) => {
-        if (sdkSessionExistsForEdition(vaultPath, sessionId, edition)) {
-          return 'active';
-        }
-        return sdkSessionExistsForEdition(vaultPath, sessionId, otherEdition)
-          ? 'other'
-          : 'unknown';
-      });
+      const resolved = resolveLegacySessionEdition(
+        meta,
+        edition,
+        sessionId => legacyLocations.get(sessionId) ?? 'unknown',
+      );
       if (resolved === undefined) {
         continue;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import type { Editor, WorkspaceLeaf } from 'obsidian';
 import { addIcon, MarkdownView, Notice, Plugin } from 'obsidian';
 
 import { QoderianStorage } from './app/storage/app-storage';
+import { measureAsync } from './core/diagnostics/performance';
 import { beginRestoreReport, reportRestoreIssue } from './core/diagnostics/restore-report';
 import { buildCursorContext } from './core/editor/editor-context';
 import { getVaultPath } from './core/fs/path';
@@ -417,9 +418,18 @@ export default class QoderianPlugin extends Plugin {
     }
     const didNormalizeModelVariants = this.normalizeModelVariantSettings();
 
-    const allMetadata = await this.storage.sessions.listMetadata();
-    await this.migrateLegacySessionEditions(allMetadata);
-    this.conversations = await this.buildConversationIndex(allMetadata);
+    const allMetadata = await measureAsync(
+      'startup.listMetadata',
+      () => this.storage.sessions.listMetadata(),
+    );
+    await measureAsync(
+      'startup.migrateLegacyEditions',
+      () => this.migrateLegacySessionEditions(allMetadata),
+    );
+    this.conversations = await measureAsync(
+      'startup.buildConversationIndex',
+      () => this.buildConversationIndex(allMetadata),
+    );
     setLocale(this.settings.locale as Locale);
 
     if (didNormalizeModelVariants) {
@@ -563,9 +573,12 @@ export default class QoderianPlugin extends Plugin {
       return;
     }
 
-    await historyService.hydrateConversationHistory(
-      conversation,
-      getVaultPath(this.app),
+    await measureAsync(
+      'history.hydrateConversation',
+      () => historyService.hydrateConversationHistory(
+        conversation,
+        getVaultPath(this.app),
+      ),
     );
   }
 

--- a/src/qoder/history/sdk-session-paths.ts
+++ b/src/qoder/history/sdk-session-paths.ts
@@ -54,13 +54,15 @@ export function getSDKSessionPath(vaultPath: string, sessionId: string): string 
   return getSDKSessionPathForEdition(vaultPath, sessionId, getActiveQoderCliEdition());
 }
 
-export function sdkSessionExistsForEdition(
+/** Async existence probe; keeps the renderer event loop free during startup. */
+export async function sdkSessionExistsForEditionAsync(
   vaultPath: string,
   sessionId: string,
   edition: QoderCliEdition,
-): boolean {
+): Promise<boolean> {
   try {
-    return existsSync(getSDKSessionPathForEdition(vaultPath, sessionId, edition));
+    await fs.access(getSDKSessionPathForEdition(vaultPath, sessionId, edition));
+    return true;
   } catch {
     return false;
   }

--- a/src/qoder/history/session-edition-filter.ts
+++ b/src/qoder/history/session-edition-filter.ts
@@ -2,7 +2,7 @@ import type { SessionMetadata } from '../../core/types';
 import type { QoderCliEdition } from '../../core/types/settings';
 
 /** Resume session id mirroring the plugin's load-time fallback (`sessionId ?? id`). */
-function resumeSessionId(meta: SessionMetadata): string | null {
+export function resumeSessionId(meta: SessionMetadata): string | null {
   return meta.sessionId !== undefined ? meta.sessionId : meta.id;
 }
 

--- a/src/qoder/history/session-edition-probe.ts
+++ b/src/qoder/history/session-edition-probe.ts
@@ -1,0 +1,73 @@
+import { mapWithConcurrency } from '../../core/async/map-with-concurrency';
+import type { SessionMetadata } from '../../core/types';
+import type { QoderCliEdition } from '../../core/types/settings';
+import { sdkSessionExistsForEditionAsync } from './sdk-session-paths';
+import { resumeSessionId, type SessionEditionLocation } from './session-edition-filter';
+
+/** Upper bound on concurrent `fs.access` probes across all workers. */
+export const PROBE_CONCURRENCY = 8;
+
+export type EditionFileExists = (
+  sessionId: string,
+  edition: QoderCliEdition,
+) => Promise<boolean>;
+
+/**
+ * Edition-file probing scoped to one load transaction. The in-flight promise
+ * (not just the resolved value) is cached, so concurrent callers asking for
+ * the same file share a single `fs.access`.
+ */
+export class SessionEditionProbe {
+  private checks = new Map<string, Promise<boolean>>();
+  private exists: EditionFileExists;
+
+  constructor(vaultPath: string, exists?: EditionFileExists) {
+    this.exists = exists
+      ?? ((sessionId, edition) => sdkSessionExistsForEditionAsync(vaultPath, sessionId, edition));
+  }
+
+  sessionFileExists(sessionId: string, edition: QoderCliEdition): Promise<boolean> {
+    const key = `${edition}:${sessionId}`;
+    let check = this.checks.get(key);
+    if (!check) {
+      check = this.exists(sessionId, edition);
+      this.checks.set(key, check);
+    }
+    return check;
+  }
+}
+
+/**
+ * Probes where each legacy session's history file lives. Workers check the
+ * active edition first and stop as soon as it exists; the other edition is
+ * only probed on a miss, so in-flight accesses stay within
+ * `PROBE_CONCURRENCY`. The resulting map feeds both the migration and index
+ * stages of the same load, so each file is accessed at most once.
+ */
+export async function probeLegacySessionLocations(
+  metadata: SessionMetadata[],
+  activeEdition: QoderCliEdition,
+  probe: SessionEditionProbe,
+): Promise<Map<string, SessionEditionLocation>> {
+  const otherEdition: QoderCliEdition = activeEdition === 'cn' ? 'global' : 'cn';
+  const targets = metadata.filter(meta => meta.edition === undefined && !!resumeSessionId(meta));
+
+  const locations = new Map<string, SessionEditionLocation>();
+  await mapWithConcurrency(targets, PROBE_CONCURRENCY, async (meta) => {
+    const sessionId = resumeSessionId(meta);
+    if (!sessionId) {
+      return;
+    }
+    if (await probe.sessionFileExists(sessionId, activeEdition)) {
+      locations.set(sessionId, 'active');
+      return;
+    }
+    if (await probe.sessionFileExists(sessionId, otherEdition)) {
+      locations.set(sessionId, 'other');
+      return;
+    }
+    locations.set(sessionId, 'unknown');
+  });
+
+  return locations;
+}

--- a/tests/unit/app/storage/session-storage.test.ts
+++ b/tests/unit/app/storage/session-storage.test.ts
@@ -79,4 +79,56 @@ describe('SessionStorage restore diagnostics', () => {
       detail: expect.stringContaining('bad.meta.json'),
     });
   });
+
+  it('reads metadata files concurrently with a bounded number in flight', async () => {
+    const fileNames = Array.from({ length: 24 }, (_, index) => `s-${index}.meta.json`);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const read = jest.fn(async (filePath: string) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return JSON.stringify({ id: filePath });
+    });
+    const listFiles = jest.fn(async () => fileNames);
+    const storage = makeStorage(read, listFiles);
+
+    beginRestoreReport();
+    const metas = await storage.listMetadata();
+
+    expect(metas).toHaveLength(24);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(8);
+    expect(finishRestoreReport()).toEqual([]);
+  });
+
+  it('keeps listing results in file order and does not block on a slow read', async () => {
+    let completed = 0;
+    const read = jest.fn(async (filePath: string) => {
+      if (filePath === 'slow.meta.json') {
+        await new Promise((resolve) => setTimeout(resolve, 120));
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      completed += 1;
+      return JSON.stringify({ id: filePath });
+    });
+    const listFiles = jest.fn(async () => ['slow.meta.json', 'a.meta.json', 'b.meta.json', 'c.meta.json']);
+    const storage = makeStorage(read, listFiles);
+
+    beginRestoreReport();
+    const listing = storage.listMetadata();
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    // The slow read is still in flight; the other three must not wait for it.
+    expect(completed).toBe(3);
+
+    const metas = await listing;
+    expect(metas.map((meta) => meta.id)).toEqual([
+      'slow.meta.json',
+      'a.meta.json',
+      'b.meta.json',
+      'c.meta.json',
+    ]);
+  });
 });

--- a/tests/unit/core/async/map-with-concurrency.test.ts
+++ b/tests/unit/core/async/map-with-concurrency.test.ts
@@ -1,0 +1,82 @@
+import { mapWithConcurrency } from '@/core/async/map-with-concurrency';
+
+function defer(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('mapWithConcurrency', () => {
+  it('returns results in input order regardless of completion order', async () => {
+    const items = [30, 5, 20, 10];
+    const results = await mapWithConcurrency(items, 4, async (ms, index) => {
+      await defer(ms);
+      return index;
+    });
+
+    expect(results).toEqual([0, 1, 2, 3]);
+  });
+
+  it('keeps in-flight work within the limit while actually running in parallel', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const items = Array.from({ length: 24 }, (_, index) => index);
+    await mapWithConcurrency(items, 8, async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await defer(5);
+      inFlight -= 1;
+    });
+
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(8);
+  });
+
+  it('lets finished workers pick up the next item instead of waiting for a slow one', async () => {
+    let completed = 0;
+    const items = ['slow', 'fast-1', 'fast-2', 'fast-3'];
+
+    const done = mapWithConcurrency(items, 2, async (item) => {
+      if (item === 'slow') {
+        await defer(120);
+      } else {
+        await defer(5);
+      }
+      completed += 1;
+      return item;
+    });
+
+    await defer(40);
+    // The slow task is still running, but the fast tasks must have finished.
+    expect(completed).toBe(3);
+
+    const results = await done;
+    expect(results).toEqual(['slow', 'fast-1', 'fast-2', 'fast-3']);
+  });
+
+  it('returns an empty array for empty input', async () => {
+    await expect(mapWithConcurrency([], 8, async () => 1)).resolves.toEqual([]);
+  });
+
+  it('clamps the worker count to the number of items', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    await mapWithConcurrency([1, 2], 8, async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await defer(5);
+      inFlight -= 1;
+    });
+
+    expect(maxInFlight).toBe(2);
+  });
+
+  it('rejects when the mapper throws', async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (item) => {
+        if (item === 2) throw new Error('boom');
+        return item;
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/tests/unit/core/diagnostics/performance.test.ts
+++ b/tests/unit/core/diagnostics/performance.test.ts
@@ -1,0 +1,39 @@
+import { measureAsync } from '@/core/diagnostics/performance';
+
+describe('measureAsync', () => {
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it('returns the wrapped result unchanged', async () => {
+    const result = await measureAsync('stage.label', async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('logs the label with an elapsed-time suffix', async () => {
+    await measureAsync('stage.label', async () => undefined);
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [line] = infoSpy.mock.calls[0];
+    expect(line).toMatch(/^\[qoderian perf\] stage\.label: \d+(\.\d+)?ms$/);
+  });
+
+  it('logs timing and rethrows when the wrapped operation fails', async () => {
+    const boom = new Error('boom');
+
+    await expect(
+      measureAsync('stage.failing', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toMatch(/^\[qoderian perf\] stage\.failing: /);
+  });
+});

--- a/tests/unit/qoder/history/session-edition-probe.test.ts
+++ b/tests/unit/qoder/history/session-edition-probe.test.ts
@@ -1,0 +1,156 @@
+import type { SessionMetadata } from '@/core/types';
+import {
+  PROBE_CONCURRENCY,
+  probeLegacySessionLocations,
+  SessionEditionProbe,
+} from '@/qoder/history/session-edition-probe';
+
+function defer(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeMeta(id: string, overrides: Partial<SessionMetadata> = {}): SessionMetadata {
+  return {
+    id,
+    title: id,
+    createdAt: 0,
+    updatedAt: 0,
+    sessionId: id,
+    ...overrides,
+  };
+}
+
+describe('SessionEditionProbe', () => {
+  it('dedupes concurrent checks for the same session file into one access', async () => {
+    const accessed: string[] = [];
+    const probe = new SessionEditionProbe('/vault', async (sessionId, edition) => {
+      accessed.push(`${edition}:${sessionId}`);
+      await defer(10);
+      return true;
+    });
+
+    const [first, second] = await Promise.all([
+      probe.sessionFileExists('s1', 'global'),
+      probe.sessionFileExists('s1', 'global'),
+    ]);
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    // The second caller must share the in-flight promise, not trigger a new access.
+    expect(accessed).toEqual(['global:s1']);
+  });
+
+  it('keeps probing distinct files distinct', async () => {
+    const probe = new SessionEditionProbe('/vault', async () => false);
+
+    await probe.sessionFileExists('s1', 'global');
+    await probe.sessionFileExists('s1', 'cn');
+    await probe.sessionFileExists('s2', 'global');
+
+    // Different edition or session id means a different cache key.
+    await expect(probe.sessionFileExists('s1', 'global')).resolves.toBe(false);
+  });
+});
+
+describe('probeLegacySessionLocations', () => {
+  it('stops after the active edition when the file exists there', async () => {
+    const accessed: string[] = [];
+    const probe = new SessionEditionProbe('/vault', async (sessionId, edition) => {
+      accessed.push(`${edition}:${sessionId}`);
+      return edition === 'global';
+    });
+
+    const locations = await probeLegacySessionLocations([makeMeta('legacy-1')], 'global', probe);
+
+    expect(accessed).toEqual(['global:legacy-1']);
+    expect(locations.get('legacy-1')).toBe('active');
+  });
+
+  it('probes both editions exactly once for missing files and caches the outcome', async () => {
+    const accessed: string[] = [];
+    const probe = new SessionEditionProbe('/vault', async (sessionId, edition) => {
+      accessed.push(`${edition}:${sessionId}`);
+      return false;
+    });
+
+    const locations = await probeLegacySessionLocations([makeMeta('gone-1')], 'global', probe);
+
+    expect(locations.get('gone-1')).toBe('unknown');
+    // Active edition first, then the other — exactly two accesses.
+    expect(accessed).toEqual(['global:gone-1', 'cn:gone-1']);
+
+    // A later stage reusing the same probe must not add any access.
+    await probe.sessionFileExists('gone-1', 'global');
+    await probe.sessionFileExists('gone-1', 'cn');
+    expect(accessed).toEqual(['global:gone-1', 'cn:gone-1']);
+  });
+
+  it('maps locations for active, other and missing legacy sessions', async () => {
+    const files = new Set(['global:in-active', 'cn:in-other']);
+    const probe = new SessionEditionProbe(
+      '/vault',
+      async (sessionId, edition) => files.has(`${edition}:${sessionId}`),
+    );
+    const metadata = [
+      makeMeta('in-active'),
+      makeMeta('in-other'),
+      makeMeta('nowhere'),
+      makeMeta('stamped', { edition: 'cn' }),
+      makeMeta('no-file', { sessionId: null }),
+      makeMeta('fallback-to-id', { sessionId: undefined }),
+    ];
+
+    const locations = await probeLegacySessionLocations(metadata, 'global', probe);
+
+    expect(locations.get('in-active')).toBe('active');
+    expect(locations.get('in-other')).toBe('other');
+    expect(locations.get('nowhere')).toBe('unknown');
+    // Stamped sessions and sessions without a resolvable session id are not probed.
+    expect(locations.has('stamped')).toBe(false);
+    expect(locations.has('no-file')).toBe(false);
+    expect(locations.get('fallback-to-id')).toBe('unknown');
+  });
+
+  it('keeps in-flight accesses within PROBE_CONCURRENCY while running in parallel', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const probe = new SessionEditionProbe('/vault', async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await defer(5);
+      inFlight -= 1;
+      return false;
+    });
+    const metadata = Array.from({ length: 24 }, (_, index) => makeMeta(`s-${index}`));
+
+    await probeLegacySessionLocations(metadata, 'global', probe);
+
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(PROBE_CONCURRENCY);
+  });
+
+  it('resolves the other edition relative to the active one', async () => {
+    const accessed: string[] = [];
+    const probe = new SessionEditionProbe('/vault', async (sessionId, edition) => {
+      accessed.push(`${edition}:${sessionId}`);
+      return edition === 'global';
+    });
+
+    const locations = await probeLegacySessionLocations([makeMeta('legacy-1')], 'cn', probe);
+
+    expect(accessed).toEqual(['cn:legacy-1', 'global:legacy-1']);
+    expect(locations.get('legacy-1')).toBe('other');
+  });
+
+  it('returns an empty map when there are no legacy sessions', async () => {
+    const probe = new SessionEditionProbe('/vault', async () => true);
+
+    const locations = await probeLegacySessionLocations(
+      [makeMeta('stamped', { edition: 'global' })],
+      'global',
+      probe,
+    );
+
+    expect(locations.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- What changed?
  - Session metadata is now read with a bounded-concurrency worker pool (`mapWithConcurrency`, in-flight cap 8, order-preserving) instead of one serial read per `.meta.json`.
  - Legacy edition history probing moved off the blocking synchronous path: a `SessionEditionProbe` performs async `fs.access` checks cached at the promise level, runs once per load transaction, and feeds both the migration and index stages so each file is accessed at most once. The pure sync strategy functions and serial metadata writes are unchanged.
  - Adds startup-stage timing (`measureAsync`) plus a deterministic session fixture generator for reproducible load measurements.
- Why is it needed?
  - With hundreds of saved sessions, startup cost grew linearly: serial metadata reads plus repeated synchronous `existsSync` probes blocked the renderer for the whole load. Measured on a real vault with 1000 sessions, startup metadata+edition stages drop from ~1.0–3.9s to ~0.4–0.5s (roughly 4–5x) in interleaved old-vs-new builds.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (3475 passed, including new probe/pool coverage)
- [x] `npm run build`
- [x] `npm run release:check`
- [x] `npm run audit:prod`
- [ ] `Tested affected qodercli behavior against a real CLI when applicable` — not applicable: no CLI interaction changed. Edition visibility was instead regression-tested end-to-end in a real Obsidian vault against generated sessions covering active/other/missing history files (visibility, stamping, and unstamped-missing behavior all unchanged).

## Safety

- [x] No credentials, private vault content, internal URLs, or personal paths are included
- [x] User-visible changes are documented in `CHANGELOG.md`